### PR TITLE
#38 the between in Award must not give anything when too small value

### DIFF
--- a/lib/fbe/award.rb
+++ b/lib/fbe/award.rb
@@ -148,8 +148,19 @@ class Fbe::Award
         v = to_val(@operands[0], bill)
         a = to_val(@operands[1], bill)
         b = to_val(@operands[2], bill)
-        v = b if v > b
-        v = a if v < a
+        return 0 if (v.positive? && v < a && v < b) || (v.negative? && v > a && v > b)
+        if a > b
+          min = b
+          max = a
+        else
+          min = a
+          max = b
+        end
+        if v < min
+          v = min
+        elsif v > max
+          v = max
+        end
         v
       else
         raise "Unknown term '#{@op}'"

--- a/lib/fbe/award.rb
+++ b/lib/fbe/award.rb
@@ -148,20 +148,10 @@ class Fbe::Award
         v = to_val(@operands[0], bill)
         a = to_val(@operands[1], bill)
         b = to_val(@operands[2], bill)
-        return 0 if (v.positive? && v < a && v < b) || (v.negative? && v > a && v > b)
-        if a > b
-          min = b
-          max = a
-        else
-          min = a
-          max = b
-        end
-        if v < min
-          v = min
-        elsif v > max
-          v = max
-        end
-        v
+        min, max = [a, b].minmax
+        return 0 if (v.positive? && v < min) || (v.negative? && v > max)
+
+        v.clamp(min, max)
       else
         raise "Unknown term '#{@op}'"
       end

--- a/test/fbe/test_award.rb
+++ b/test/fbe/test_award.rb
@@ -79,8 +79,22 @@ class TestAward < Minitest::Test
       '(let x 25)' => 0,
       '(award (give 25 "for being a good boy"))' => 25,
       '(award (give (between 42 -10 -50) "empty"))' => -10,
-      '(award (give (between -3 -10 -50) "empty"))' => -10,
+      '(award (give (between -3 -10 -50) "empty"))' => 0,
       '(award (give (between -100 -50 -10) "empty"))' => -50
+    }.each do |q, v|
+      a = Fbe::Award.new(q)
+      assert_equal(v, a.bill.points, q)
+    end
+  end
+
+  def test_must_not_give_anything_when_too_small_value
+    {
+      '(award (give (between 13 5 20)))' => 13,
+      '(award (give (between 3 5 20)))' => 0,
+      '(award (give (between 25 5 20)))' => 20,
+      '(award (give (between -2 -10 -30)))' => 0,
+      '(award (give (between -15 -10 -30)))' => -15,
+      '(award (give (between -50 -10 -30)))' => -30
     }.each do |q, v|
       a = Fbe::Award.new(q)
       assert_equal(v, a.bill.points, q)


### PR DESCRIPTION
To implement task #38, I modified the part for :between. Also the test `test_some_terms` was changed. This case is similar to `(award (give (between -2 -10 -30)))` and the expected value should be zero