### PR TITLE
select only resolved comments

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -82,7 +82,9 @@ class Fbe::Graph
         }
       GRAPHQL
     )
-    result&.to_h&.dig('repository', 'pullRequest', 'reviewThreads', 'nodes') || []
+    result&.to_h&.dig('repository', 'pullRequest', 'reviewThreads', 'nodes')&.select do |thread|
+      thread['isResolved']
+    end || []
   end
 
   def total_commits(owner, name, branch)

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -91,6 +91,14 @@ class TestGitHubGraph < Minitest::Test
     assert(0, result.count)
   end
 
+  def test_does_not_count_unresolved_conversations
+    skip # it's a "live" test, run it manually if you need it
+    WebMock.allow_net_connect!
+    g = Fbe.github_graph(options: Judges::Options.new, loog: Loog::NULL, global: {})
+    result = g.resolved_conversations('zerocracy', 'judges-action', 296)
+    assert_equal(0, result.count)
+  end
+
   def test_gets_total_commits_of_repo
     skip # it's a "live" test, run it manually if you need it
     WebMock.allow_net_connect!


### PR DESCRIPTION
@yegor256 this pr fixes https://github.com/zerocracy/judges-action/issues/308 
I think it is more logical to fix the `Fbe.github_graph.resolved_conversations` method, because this function should only return `resolved` conversations, but now it does not. Thus, we will not have to fix anything in `judges-action`, other than upgrading the fbe version.