### PR TITLE
#197: implement persisted sqlite store for Faraday::HttpCache, add `sqlite_cache otions` for use it in Fbe.octo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 rdoc/
 vendor/
 .claude/
+.test.db*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ PATH
       obk (> 0)
       octokit (~> 10.0)
       others (> 0)
+      sqlite3 (~> 2.6)
       tago (> 0)
       verbose (> 0)
 
@@ -217,6 +218,10 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.6.0-arm64-darwin)
+    sqlite3 (2.6.0-x64-mingw-ucrt)
+    sqlite3 (2.6.0-x86_64-darwin)
+    sqlite3 (2.6.0-x86_64-linux-gnu)
     strscan (3.1.5)
     tago (0.1.0)
     timeout (0.4.3)

--- a/fbe.gemspec
+++ b/fbe.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'obk', '>0'
   s.add_dependency 'octokit', '~>10.0'
   s.add_dependency 'others', '>0'
+  s.add_dependency 'sqlite3', '~> 2.6'
   s.add_dependency 'tago', '>0'
   s.add_dependency 'verbose', '>0'
   s.metadata['rubygems_mfa_required'] = 'true'

--- a/lib/fbe/middleware/sqlite_store.rb
+++ b/lib/fbe/middleware/sqlite_store.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'sqlite3'
+require_relative '../../fbe'
+require_relative '../../fbe/middleware'
+
+# Persisted SQLite store for Faraday::HttpCache
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Zerocracy
+# License:: MIT
+class Fbe::Middleware::SqliteStore
+  def initialize(path)
+    @path = path
+    open
+    prepare
+    at_exit { close }
+  end
+
+  def read(key)
+    value = perform { _1.execute('SELECT value FROM cache WHERE key = ? LIMIT 1', [key]) }.dig(0, 0)
+    Marshal.load(value) if value
+  end
+
+  def delete(key)
+    perform { _1.execute('DELETE FROM cache WHERE key = ?', [key]) }
+    nil
+  end
+
+  def write(key, value)
+    value = Marshal.dump(value)
+    perform do |tdb|
+      tdb.execute(<<~SQL, [key, value])
+        INSERT INTO cache(key, value) VALUES(?1, ?2)
+        ON CONFLICT(key) DO UPDATE SET value = ?2
+      SQL
+    end
+    nil
+  end
+
+  def open
+    return if @db
+    @db = SQLite3::Database.new(@path)
+  end
+
+  def prepare
+    perform do |tdb|
+      tdb.execute 'CREATE TABLE IF NOT EXISTS cache(key TEXT UNIQUE NOT NULL, value TEXT);'
+      tdb.execute 'CREATE INDEX IF NOT EXISTS key_idx ON cache(key);'
+    end
+  end
+
+  def close
+    return if !@db || @db.closed?
+    @db.close
+    @db = nil
+  end
+
+  def clear
+    perform { _1.execute 'DELETE FROM cache;' }
+  end
+
+  def drop
+    perform { _1.execute 'DROP TABLE IF EXISTS cache;' }
+  end
+
+  def all
+    perform { _1.execute('SELECT key, value FROM cache') }
+  end
+
+  private
+
+  def perform(&)
+    @db.transaction(&)
+  end
+end

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -15,6 +15,7 @@ require_relative '../fbe'
 require_relative 'middleware'
 require_relative 'middleware/formatter'
 require_relative 'middleware/trace'
+require_relative 'middleware/sqlite_store'
 
 # Makes a call to the GitHub API.
 #
@@ -78,7 +79,8 @@ def Fbe.octo(options: $options, global: $global, loog: $loog)
               methods: [:get],
               backoff_factor: 2
             )
-            builder.use(Faraday::HttpCache, serializer: Marshal, shared_cache: false, logger: Loog::NULL)
+            store = Fbe::Middleware::SqliteStore.new(options.sqlite_cache) if options.sqlite_cache
+            builder.use(Faraday::HttpCache, store: store, serializer: Marshal, shared_cache: false, logger: Loog::NULL)
             builder.use(Octokit::Response::RaiseError)
             builder.use(Faraday::Response::Logger, loog, formatter: Fbe::Middleware::Formatter)
             builder.use(Fbe::Middleware::Trace, trace)

--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../../test__helper'
+require_relative '../../../lib/fbe/middleware'
+require_relative '../../../lib/fbe/middleware/sqlite_store'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024-2025 Zerocracy
+# License:: MIT
+class SqliteStoreTest < Fbe::Test
+  attr_reader :store
+
+  def self.store
+    @store ||=
+      begin
+        path = File.expand_path('../../../.test.db1', __dir__)
+        Fbe::Middleware::SqliteStore.new(path)
+      end
+  end
+
+  def setup
+    @store = self.class.store
+    store.clear
+  end
+
+  def test_sqlite_store
+    assert_nil(store.read('my_key'))
+    assert_nil(store.delete('my_key'))
+    assert_nil(store.write('my_key', 'some value'))
+    assert_equal('some value', store.read('my_key'))
+    assert_nil(store.write('my_key', 'some value 2'))
+    assert_equal('some value 2', store.read('my_key'))
+    assert_nil(store.delete('my_key'))
+    assert_nil(store.read('my_key'))
+  end
+
+  def test_sqlite_store_empty_all
+    assert_empty(store.all)
+  end
+end


### PR DESCRIPTION
Closes #197 