### PR TITLE
#205: add version for sqlite cache store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 
 gem 'minitest', '~>5.25', require: false
 gem 'minitest-reporters', '~>1.7', require: false
+gem 'minitest-stub-const', '~>0.6', require: false
 gem 'os', '~>1.1', require: false
 gem 'qbash', '~>0.4', require: false
 gem 'rake', '~>13.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    minitest-stub-const (0.6)
     moments (0.3.0)
     multipart-post (2.4.1)
     net-http (0.6.0)
@@ -258,6 +259,7 @@ DEPENDENCIES
   fbe!
   minitest (~> 5.25)
   minitest-reporters (~> 1.7)
+  minitest-stub-const (~> 0.6)
   os (~> 1.1)
   qbash (~> 0.4)
   rake (~> 13.3)

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -77,12 +77,19 @@ def Fbe.octo(options: $options, global: $global, loog: $loog)
               backoff_factor: 2
             )
             if options.sqlite_cache
-              store = Fbe::Middleware::SqliteStore.new(options.sqlite_cache)
+              store = Fbe::Middleware::SqliteStore.new(options.sqlite_cache, Fbe::VERSION)
               loog.info(
                 "Using HTTP cache in SQLite file: #{store.path} (" \
                 "#{File.exist?(store.path) ? "#{File.size(store.path)} bytes" : 'file is absent'}" \
                 ')'
               )
+              if store.different_versions?
+                loog.info(
+                  "Fbe has different version from cache store '#{Fbe::VERSION}!#{store.version}' " \
+                  'and will be cleared'
+                )
+                store.clear
+              end
               builder.use(
                 Faraday::HttpCache,
                 store:, serializer: JSON, shared_cache: false, logger: Loog::NULL

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -83,13 +83,6 @@ def Fbe.octo(options: $options, global: $global, loog: $loog)
                 "#{File.exist?(store.path) ? "#{File.size(store.path)} bytes" : 'file is absent'}" \
                 ')'
               )
-              if store.different_versions?
-                loog.info(
-                  "Fbe has different version from cache store '#{Fbe::VERSION}!#{store.version}' " \
-                  'and will be cleared'
-                )
-                store.clear
-              end
               builder.use(
                 Faraday::HttpCache,
                 store:, serializer: JSON, shared_cache: false, logger: Loog::NULL

--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -112,26 +112,23 @@ class SqliteStoreTest < Fbe::Test
   def test_different_versions
     with_tmpfile('d.db') do |f|
       Fbe::Middleware::SqliteStore.new(f, '0.0.1').then do |store|
-        assert_equal('0.0.1', store.version)
-        refute_predicate(store, :different_versions?)
-        store.write('key', 'some value')
+        store.write('kkk1', 'some value')
+        store.write('kkk2', 'another value')
+      end
+      Fbe::Middleware::SqliteStore.new(f, '0.0.1').then do |store|
+        assert_equal('some value', store.read('kkk1'))
+        assert_equal('another value', store.read('kkk2'))
       end
       Fbe::Middleware::SqliteStore.new(f, '0.0.2').then do |store|
-        assert_equal('0.0.1', store.version)
-        store.write('key2', 'some value2')
-        assert_equal(2, store.all.size)
-        assert_predicate(store, :different_versions?)
-        store.clear
-        assert_equal('0.0.2', store.version)
-        refute_predicate(store, :different_versions?)
-        assert_empty(store.all)
+        assert_nil(store.read('kkk1'))
+        assert_nil(store.read('kkk2'))
       end
     end
   end
 
   def test_initialize_wrong_version
     with_tmpfile('e.db') do |f|
-      msg = 'Fbe version cannot be nil or empty'
+      msg = 'Version cannot be nil or empty'
       assert_raises(ArgumentError) { Fbe::Middleware::SqliteStore.new(f, nil) }.then do |ex|
         assert_match(msg, ex.message)
       end

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -405,4 +405,34 @@ class TestOcto < Fbe::Test
       assert_path_exists(file)
     end
   end
+
+  def test_clear_sqlite_store_if_different_versions
+    WebMock.disable_net_connect!
+    Dir.mktmpdir do |dir|
+      global = {}
+      stub_request(:get, 'https://api.github.com/user/42')
+        .to_return(
+          status: 200,
+          body: { login: 'user1' }.to_json,
+          headers: {
+            'Content-Type' => 'application/json',
+            'Cache-Control' => 'public, max-age=60, s-maxage=60',
+            'Etag' => 'W/"2ff9dd4c3153f006830b2b8b721f6a4bb400a1eb81a2e1fa0a3b846ad349b9ec"',
+            'Last-Modified' => 'Wed, 01 May 2025 20:00:00 GMT'
+          }
+        )
+      sqlite_cache = File.expand_path('test.db', dir)
+      Fbe.stub_const(:VERSION, '0.0.1') do
+        o = Fbe.octo(loog: Loog::NULL, global:, options: Judges::Options.new({ 'sqlite_cache' => sqlite_cache }))
+        assert_equal('user1', o.user_name_by_id(42))
+      end
+      global = {}
+      Fbe.stub_const(:VERSION, '0.0.2') do
+        loog = Loog::Buffer.new
+        o = Fbe.octo(loog:, global:, options: Judges::Options.new({ 'sqlite_cache' => sqlite_cache }))
+        assert_equal('user1', o.user_name_by_id(42))
+        assert_match("Fbe has different version from cache store '0.0.2!0.0.1' and will be cleared", loog.to_s)
+      end
+    end
+  end
 end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -31,6 +31,7 @@ end
 require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
+require 'minitest/stub_const'
 require 'minitest/autorun'
 require 'webmock/minitest'
 require_relative '../lib/fbe'


### PR DESCRIPTION
Closes #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced version tracking in the SQLite cache store, allowing detection and handling of version mismatches.
  - Cache is now automatically cleared if a version difference is detected.

- **Bug Fixes**
  - Improved cache consistency by ensuring outdated cache data is removed when the application version changes.

- **Tests**
  - Added and updated tests to verify version tracking, cache clearing, and error handling for invalid version inputs.
  - Added tests to confirm cache refresh behavior when using different application versions.

- **Chores**
  - Added new test dependencies to support enhanced testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->