### PR TITLE
#209: make avoid caching if value size is bigger than 10K in `Fbe::Middleware::SqliteStore`

### DIFF
--- a/lib/fbe/middleware/sqlite_store.rb
+++ b/lib/fbe/middleware/sqlite_store.rb
@@ -41,6 +41,7 @@ class Fbe::Middleware::SqliteStore
       req['url'].include?('?') || req['method'] != 'get'
     end
     value = JSON.dump(value)
+    return if value.bytesize > 10_000
     perform do |t|
       t.execute(<<~SQL, [key, value])
         INSERT INTO cache(key, value) VALUES(?1, ?2)

--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -138,6 +138,21 @@ class SqliteStoreTest < Fbe::Test
     end
   end
 
+  def test_skip_write_if_value_more_then_10k_bytes
+    with_tmpfile('a.db') do |f|
+      Fbe::Middleware::SqliteStore.new(f, '0.0.1').then do |store|
+        store.write('a', 'a' * 9_997)
+        store.write('b', 'b' * 9_998)
+        store.write('c', 'c' * 9_999)
+        store.write('d', 'd' * 10_000)
+        assert_equal('a' * 9_997, store.read('a'))
+        assert_equal('b' * 9_998, store.read('b'))
+        assert_nil(store.read('c'))
+        assert_nil(store.read('d'))
+      end
+    end
+  end
+
   private
 
   def with_tmpfile(name = 'test.db', &)


### PR DESCRIPTION
Closes #209 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a size limit for cache entries, preventing storage of values exceeding 10,000 bytes.
- **Tests**
  - Introduced tests to verify that oversized values are not stored in the cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->