### PR TITLE
#225: fetch rate_limit by making a new request

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -150,14 +150,14 @@ def Fbe.octo(options: $options, global: $global, loog: $loog)
                 .join("\n")
               @loog.info(
                 "GitHub API trace (#{grouped.count} URLs vs #{@trace.count} requests, " \
-                "#{@origin.rate_limit.remaining} quota left):\n#{message}"
+                "#{@origin.rate_limit!.remaining} quota left):\n#{message}"
               )
               @trace.clear
             end
           end
 
           def off_quota?(threshold: 50)
-            left = @origin.rate_limit.remaining
+            left = @origin.rate_limit!.remaining
             if left < threshold
               @loog.info("Too much GitHub API quota consumed already (#{left} < #{threshold}), stopping")
               true
@@ -258,6 +258,7 @@ class Fbe::FakeOctokit
     end
     o
   end
+  alias rate_limit! rate_limit
 
   # Lists repositories for a user or organization.
   #

--- a/test/fbe/test_conclude.rb
+++ b/test/fbe/test_conclude.rb
@@ -79,8 +79,12 @@ class TestConclude < Fbe::Test
       }
     )
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      body: 'hm...', headers: { 'X-RateLimit-Remaining' => '777' }
-    ).times(1)
+      { body: 'hm...', headers: { 'X-RateLimit-Remaining' => '777' } },
+      { body: 'hm...', headers: { 'X-RateLimit-Remaining' => '777' } },
+      { body: 'hm...', headers: { 'X-RateLimit-Remaining' => '777' } },
+      { body: 'hm...', headers: { 'X-RateLimit-Remaining' => '999' } },
+      { body: 'hm...', headers: { 'X-RateLimit-Remaining' => '9' } }
+    )
     global = {}
     o = Fbe.octo(loog: Loog::NULL, options:, global:)
     Fbe.conclude(fb:, judge: 'boom', loog: Loog::NULL, options:, global:) do


### PR DESCRIPTION
Closes #225 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced rate limit tests to simulate multiple sequential API responses with varying quota values.
  * Improved test coverage for quota depletion, recovery, and trace output.
  * Added a new test to verify behavior when fetching rate limits through multiple requests until exhaustion.

* **Chores**
  * Updated method usage to align with new method alias for rate limit retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->