### PR TITLE
#235: make body shorten for 50x errors in `Fbe::Middleware::Formatter`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,5 @@ Metrics/ParameterLists:
   Enabled: false
 Layout/MultilineAssignmentLayout:
   Enabled: true
+Style/RequireOrder:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: MIT
 
 require 'qbash'
-require 'rubygems'
 require 'rake'
 require 'rake/clean'
+require 'rubygems'
 
 def name
   @name ||= File.basename(Dir['*.gemspec'].first, '.*')

--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -6,8 +6,8 @@
 require 'tago'
 require_relative '../fbe'
 require_relative 'fb'
-require_relative 'octo'
 require_relative 'if_absent'
+require_relative 'octo'
 
 # Creates an instance of {Fbe::Conclude} and evals it with the block provided.
 #

--- a/lib/fbe/fb.rb
+++ b/lib/fbe/fb.rb
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require 'factbase/cached/cached_factbase'
+require 'factbase/indexed/indexed_factbase'
 require 'factbase/logged'
 require 'factbase/pre'
 require 'factbase/rules'
-require 'factbase/cached/cached_factbase'
-require 'factbase/indexed/indexed_factbase'
 require 'factbase/sync/sync_factbase'
 require 'judges'
 require 'loog'

--- a/lib/fbe/just_one.rb
+++ b/lib/fbe/just_one.rb
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-require 'time'
 require 'others'
+require 'time'
 require_relative '../fbe'
 require_relative 'fb'
 

--- a/lib/fbe/middleware/formatter.rb
+++ b/lib/fbe/middleware/formatter.rb
@@ -5,6 +5,7 @@
 
 require 'faraday'
 require 'faraday/logging/formatter'
+require 'ellipsized'
 require_relative '../../fbe'
 require_relative '../../fbe/middleware'
 
@@ -76,7 +77,7 @@ class Fbe::Middleware::Formatter < Faraday::Logging::Formatter
           "HTTP/1.1 #{http.status}",
           shifted(apply_filters(dump_headers(http.response_headers))),
           '',
-          shifted(apply_filters(truncate(http.response_body)))
+          shifted(apply_filters(http.response_body&.ellipsized(100, :right)))
         ].join("\n")
       )
       return
@@ -119,17 +120,5 @@ class Fbe::Middleware::Formatter < Faraday::Logging::Formatter
   def dump_headers(headers)
     return '' if headers.nil?
     headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
-  end
-
-  # Truncates text if it is longer than a specified :length by appending :omission
-  #
-  # @param [String, nil] txt The text to truncate
-  # @param [Integer] length The number of characters to keep
-  # @param [String] omission The string that will be added to the end as an omission
-  # @return [String] The truncated text, or an empty string if input was nil
-  def truncate(txt, length: 100, omission: '...')
-    return '' if txt.nil?
-    return txt if txt.length <= length
-    "#{txt.slice(0, length)}#{omission}"
   end
 end

--- a/lib/fbe/middleware/formatter.rb
+++ b/lib/fbe/middleware/formatter.rb
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'ellipsized'
 require 'faraday'
 require 'faraday/logging/formatter'
-require 'ellipsized'
 require_relative '../../fbe'
 require_relative '../../fbe/middleware'
 

--- a/lib/fbe/middleware/sqlite_store.rb
+++ b/lib/fbe/middleware/sqlite_store.rb
@@ -3,12 +3,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-require 'zlib'
 require 'filesize'
 require 'json'
 require 'loog'
 require 'sqlite3'
 require 'time'
+require 'zlib'
 require_relative '../../fbe'
 require_relative '../../fbe/middleware'
 

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -6,10 +6,10 @@
 require 'faraday'
 require 'loog'
 require 'securerandom'
-require_relative '../../test__helper'
 require_relative '../../../lib/fbe'
 require_relative '../../../lib/fbe/middleware'
 require_relative '../../../lib/fbe/middleware/formatter'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -69,7 +69,7 @@ class LoggingFormatterTest < Fbe::Test
         %r{HTTP/1.1 502},
         /x-github-api-version-selected: "2022-11-28"/,
         %r{content-type: "text/html; charset=utf-8"},
-        "#{body.slice(0, 100)}..."
+        "#{body.slice(0, 97)}..."
       ].each { |ptn| assert_match(ptn, str) }
     end
   end

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -5,6 +5,7 @@
 
 require 'faraday'
 require 'loog'
+require 'securerandom'
 require_relative '../../test__helper'
 require_relative '../../../lib/fbe'
 require_relative '../../../lib/fbe/middleware'
@@ -49,9 +50,38 @@ class LoggingFormatterTest < Fbe::Test
     end
   end
 
+  def test_truncate_body_for_error_text_response
+    body = SecureRandom.alphanumeric(120)
+    log_it(
+      status: 502,
+      response_body: body,
+      response_headers: {
+        'content-type' => 'text/html; charset=utf-8',
+        'x-github-api-version-selected' => '2022-11-28'
+      }
+    ) do |loog|
+      str = loog.to_s
+      refute_empty(str)
+      [
+        %r{http://example.com},
+        /Authorization:/,
+        /some request body/,
+        %r{HTTP/1.1 502},
+        /x-github-api-version-selected: "2022-11-28"/,
+        %r{content-type: "text/html; charset=utf-8"},
+        "#{body.slice(0, 100)}..."
+      ].each { |ptn| assert_match(ptn, str) }
+    end
+  end
+
   private
 
-  def log_it(status:, method: :get)
+  def log_it(
+    status:,
+    method: :get,
+    response_body: '{"message": "hello, world!"}',
+    response_headers: { 'content-type' => 'application/json', 'x-github-api-version-selected' => '2022-11-28' }
+  )
     loog = Loog::Buffer.new
     formatter = Fbe::Middleware::Formatter.new(logger: loog, options: {})
     formatter.request(
@@ -67,16 +97,7 @@ class LoggingFormatterTest < Fbe::Test
       )
     )
     formatter.response(
-      Faraday::Env.from(
-        {
-          status:,
-          response_body: '{"message": "hello, world!"}',
-          response_headers: {
-            'content-type' => 'application/json',
-            'x-github-api-version-selected' => '2022-11-28'
-          }
-        }
-      )
+      Faraday::Env.from({ status:, response_body:, response_headers: })
     )
     yield loog
   end

--- a/test/fbe/middleware/test_rate_limit.rb
+++ b/test/fbe/middleware/test_rate_limit.rb
@@ -5,10 +5,10 @@
 
 require 'faraday'
 require 'webmock'
-require_relative '../../test__helper'
 require_relative '../../../lib/fbe'
 require_relative '../../../lib/fbe/middleware'
 require_relative '../../../lib/fbe/middleware/rate_limit'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -3,11 +3,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-require 'securerandom'
 require 'qbash'
-require_relative '../../test__helper'
+require 'securerandom'
 require_relative '../../../lib/fbe/middleware'
 require_relative '../../../lib/fbe/middleware/sqlite_store'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/middleware/test_trace.rb
+++ b/test/fbe/middleware/test_trace.rb
@@ -6,10 +6,10 @@
 require 'faraday'
 require 'faraday/http_cache'
 require 'webmock'
-require_relative '../../test__helper'
 require_relative '../../../lib/fbe'
 require_relative '../../../lib/fbe/middleware'
 require_relative '../../../lib/fbe/middleware/trace'
+require_relative '../../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -4,10 +4,10 @@
 # SPDX-License-Identifier: MIT
 
 require 'judges/options'
-require 'webmock/minitest'
 require 'loog'
-require_relative '../test__helper'
+require 'webmock/minitest'
 require_relative '../../lib/fbe/github_graph'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/test_if_absent.rb
+++ b/test/fbe/test_if_absent.rb
@@ -3,11 +3,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-require 'tmpdir'
 require 'factbase'
 require 'loog'
-require_relative '../test__helper'
+require 'tmpdir'
 require_relative '../../lib/fbe/if_absent'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/test_just_one.rb
+++ b/test/fbe/test_just_one.rb
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
-require_relative '../test__helper'
 require_relative '../../lib/fbe/just_one'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/fbe/test_unmask_repos.rb
+++ b/test/fbe/test_unmask_repos.rb
@@ -5,8 +5,8 @@
 
 require 'judges/options'
 require 'loog'
-require_relative '../test__helper'
 require_relative '../../lib/fbe/unmask_repos'
+require_relative '../test__helper'
 
 # Test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -32,8 +32,8 @@ require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 require 'loog'
-require 'minitest/stub_const'
 require 'minitest/autorun'
+require 'minitest/stub_const'
 require 'webmock/minitest'
 require_relative '../lib/fbe'
 

--- a/test/test_fbe.rb
+++ b/test/test_fbe.rb
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-require_relative 'test__helper'
 require_relative '../lib/fbe'
+require_relative 'test__helper'
 
 # Main module test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)


### PR DESCRIPTION
Closes #235 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error logging for server responses with status 500 or higher and text-based content, including detailed request and response information with truncated response bodies for readability.

* **Tests**
  * Added tests to verify that long text response bodies in error logs are truncated appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->