### PR TITLE
#237: implement remove old keys in `Fbe::Middleware::SqliteStore`

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -93,7 +93,9 @@ def Fbe.octo(options: $options, global: $global, loog: $loog)
             if options.sqlite_cache
               maxsize = Filesize.from(options.sqlite_cache_maxsize || '100M').to_i
               maxvsize = Filesize.from(options.sqlite_cache_maxvsize || '100K').to_i
-              store = Fbe::Middleware::SqliteStore.new(options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:)
+              store = Fbe::Middleware::SqliteStore.new(
+                options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24
+              )
               loog.info(
                 "Using HTTP cache in SQLite file: #{store.path} (" \
                 "#{File.exist?(store.path) ? Filesize.from(File.size(store.path).to_s).pretty : 'file is absent'}, " \


### PR DESCRIPTION
Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced time-to-live (TTL) support for cache entries, allowing automatic expiration and cleanup of old cache data.
* **Bug Fixes**
  * Improved database schema migration to ensure compatibility and prevent errors when upgrading cache storage.
* **Tests**
  * Added tests to verify schema upgrades, TTL parameter validation, and correct key expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->