### PR TITLE
#243: make `sqlite_cache_min_age` option for overwrite max-age in cache-control

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -93,8 +93,9 @@ def Fbe.octo(options: $options, global: $global, loog: $loog)
             if options.sqlite_cache
               maxsize = Filesize.from(options.sqlite_cache_maxsize || '100M').to_i
               maxvsize = Filesize.from(options.sqlite_cache_maxvsize || '100K').to_i
+              cache_min_age = options.sqlite_cache_min_age&.to_i
               store = Fbe::Middleware::SqliteStore.new(
-                options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24
+                options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24, cache_min_age:
               )
               loog.info(
                 "Using HTTP cache in SQLite file: #{store.path} (" \


### PR DESCRIPTION
Closes #243 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a minimum cache age for HTTP responses stored in the SQLite cache, ensuring cache-control headers reflect this setting.

* **Bug Fixes**
  * Improved validation for cache age settings to prevent invalid values.

* **Tests**
  * Expanded test coverage for cache age behavior and cache-control header handling in the SQLite cache.
  * Added tests to verify correct enforcement and validation of the minimum cache age setting.
  * Added tests to confirm cache behavior respects the configured minimum age during repeated data fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->