### PR TITLE
#263: reduce execution time for test `test_shrink_cache_if_more_then_10_mb`

### DIFF
--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -155,7 +155,6 @@ class SqliteStoreTest < Fbe::Test
   def test_shrink_cache_if_more_then_10_mb
     with_tmpfile('large.db') do |f|
       Fbe::Middleware::SqliteStore.new(f, '0.0.1', loog: fake_loog).then do |store|
-        key = 'aaa'
         store.write('a', 'aa')
         Time.stub(:now, (Time.now - (5 * 60 * 60)).round) do
           store.write('b', 'bb')
@@ -163,8 +162,9 @@ class SqliteStoreTest < Fbe::Test
         end
         assert_equal('cc', store.read('c'))
         Time.stub(:now, rand((Time.now - (5 * 60 * 60))..Time.now).round) do
-          value = SecureRandom.alphanumeric(2048)
-          10_240.times do
+          key = 'a' * 65_536
+          value = SecureRandom.alphanumeric(8_192)
+          52.times do
             store.write(key, value)
             key = key.next
           end


### PR DESCRIPTION
Before
```
SqliteStoreTest
  test_shrink_cache_if_more_then_10_mb                            PASS (1.51s)
```

After
```
SqliteStoreTest
  test_shrink_cache_if_more_then_10_mb                            PASS (0.05s)
```

Closes #263 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated boundary-condition scenarios for the SQLite-backed store to use larger values and very long keys across sequential writes.
  * Reduced iteration counts while keeping data volume sufficient to hit size thresholds for write skipping and cache shrinking.
  * Test data now uses 8 KB values and 52 successive keys, including an initial extremely long key, to reflect boundary conditions.
  * No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->