### PR TITLE
#297: implement store single issues without turning them into pairs in `Fbe::Tombstone`

### DIFF
--- a/lib/fbe/tombstone.rb
+++ b/lib/fbe/tombstone.rb
@@ -34,7 +34,7 @@ class Fbe::Tombstone
         n.repo = repo
       end
     f.send(:"#{@fid}=", SecureRandom.random_number(99_999)) if f[@fid].nil?
-    nn = f['issues']&.map { |ii| ii.split('-').map(&:to_i) } || []
+    nn = f['issues']&.map { |ii| ii.split('-').map(&:to_i).then { |ii| ii.size == 1 ? ii << ii[0] : ii } } || []
     issue = [issue] unless issue.is_a?(Array)
     issue.each do |i|
       nn << [i, i]
@@ -47,7 +47,9 @@ class Fbe::Tombstone
           merged << [a, b]
         end
       end
-    Fbe.overwrite(f, 'issues', merged.map { |ii| "#{ii[0]}-#{ii[1]}" }, fb: @fb, fid: @fid)
+    Fbe.overwrite(
+      f, 'issues', merged.map { |ii| ii[0] == ii[1] ? ii[0].to_s : "#{ii[0]}-#{ii[1]}" }, fb: @fb, fid: @fid
+    )
   end
 
   # Is it there?

--- a/lib/fbe/tombstone.rb
+++ b/lib/fbe/tombstone.rb
@@ -66,7 +66,7 @@ class Fbe::Tombstone
     issue.all? do |i|
       f['issues'].any? do |ii|
         a, b = ii.split('-').map(&:to_i)
-        (a..b).cover?(i)
+        b.nil? ? a == i : (a..b).cover?(i)
       end
     end
   end

--- a/test/fbe/test_tombstone.rb
+++ b/test/fbe/test_tombstone.rb
@@ -71,6 +71,23 @@ class TestTombstone < Fbe::Test
     assert_equal(%w[4-6 10-14], f['issues'])
     Fbe.overwrite(f, 'issues', %w[14-15 8-8 4-5 4-4 5-6 5-5 4-6 10-13], fb:)
     ts.bury!(where, repo, 20)
-    assert_equal(%w[4-6 8-8 10-15 20-20], fb.query('(always)').each.to_a.first['issues'])
+    assert_equal(%w[4-6 8 10-15 20], fb.query('(always)').each.to_a.first['issues'])
+  end
+
+  def test_store_single_issues_without_turning_them_into_pairs
+    where = 'github'
+    repo = 42
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.what = 'tombstone'
+      f.where = where
+      f.repo = repo
+      Fbe.overwrite(f, 'issues', %w[207 209-209 211-211 214-214 216-220 224-224 227-227 230], fb:)
+    end
+    ts = Fbe::Tombstone.new(fb:)
+    ts.bury!(where, repo, 226)
+    f = fb.query('(always)').each.to_a.first
+    assert_equal(%w[207 209 211 214 216-220 224 226-227 230], f['issues'])
   end
 end

--- a/test/fbe/test_tombstone.rb
+++ b/test/fbe/test_tombstone.rb
@@ -89,5 +89,13 @@ class TestTombstone < Fbe::Test
     ts.bury!(where, repo, 226)
     f = fb.query('(always)').each.to_a.first
     assert_equal(%w[207 209 211 214 216-220 224 226-227 230], f['issues'])
+    assert(ts.has?(where, repo, 216))
+    assert(ts.has?(where, repo, 217))
+    assert(ts.has?(where, repo, 218))
+    assert(ts.has?(where, repo, 220))
+    refute(ts.has?(where, repo, 206))
+    refute(ts.has?(where, repo, 215))
+    refute(ts.has?(where, repo, 221))
+    refute(ts.has?(where, repo, 231))
   end
 end


### PR DESCRIPTION
Closes #297 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Properly handle single issue entries by normalizing and preserving singleton representations.
  * Serialize single issues as plain numbers instead of “x-x” (e.g., “8” not “8-8”).
  * Preserve existing singletons when merging; only form ranges for adjacent issues (e.g., “226-227”).

* **Tests**
  * Updated expectations for singleton formatting.
  * Added coverage to ensure singles stay singles and merges produce correct ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->