### PR TITLE
judges-action#1100: implement `Fbe::Graph#pull_requests_with_reviews` and `Fbe::Graph#pull_request_reviews`

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -249,6 +249,7 @@ class Fbe::Iterate
     repos = Fbe.unmask_repos(
       loog: @loog, options: @options, global: @global, quota_aware: @quota_aware
     ).map { |n| oct.repo_id_by_name(n) }
+    started = Time.now
     restarted = []
     before =
       repos.to_h do |repo|


### PR DESCRIPTION
Need for https://github.com/zerocracy/judges-action/issues/1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Retrieve pull requests with associated review details.
  - Fetch reviews for multiple pull requests in one call.
  - Pagination support for both pull lists and reviews.
  - Mocked data paths for offline/testing scenarios.

- Chores
  - Enhanced logging to include elapsed time when quota/rate limits halt processing.

- Tests
  - Added tests validating pull request + review retrieval and pagination behavior using mocked responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->