### PR TITLE
#322: implement `Fbe.over?` for check github quota, lifetime, and timeout

### DIFF
--- a/lib/fbe/over.rb
+++ b/lib/fbe/over.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../fbe'
+require_relative 'octo'
+
+# Check GitHub API quota, lifetime, and timeout.
+#
+# @param [Hash] global Hash of global options
+# @param [Judges::Options] options The options available globally
+# @param [Loog] loog Logging facility
+# @param [Time] epoch When the entire update started
+# @param [Time] kickoff When the particular judge started
+# @param [Boolean] quota_aware Enable or disable check of GitHub API quota
+# @param [Boolean] lifetime_aware Enable or disable check of lifetime limitations
+# @param [Boolean] timeout_aware Enable or disable check of timeout limitations
+# @return [Boolean] check result
+def Fbe.over?(
+  global: $global, options: $options, loog: $loog,
+  epoch: $epoch || Time.now, kickoff: $kickoff || Time.now,
+  quota_aware: true, lifetime_aware: true, timeout_aware: true
+)
+  if quota_aware && Fbe.octo(loog:, options:, global:).off_quota?(threshold: 100)
+    loog.info('We are off GitHub quota, time to stop')
+    return true
+  end
+  if lifetime_aware && options.lifetime && Time.now - epoch > options.lifetime * 0.9
+    loog.info("We ran out of lifetime (#{epoch.ago} already), must stop here")
+    return true
+  end
+  if timeout_aware && options.timeout && Time.now - kickoff > options.timeout * 0.9
+    loog.info("We've spent more than #{kickoff.ago}, must stop here")
+    return true
+  end
+  false
+end

--- a/test/fbe/test_over.rb
+++ b/test/fbe/test_over.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'judges/options'
+require 'loog'
+require_relative '../../lib/fbe/octo'
+require_relative '../../lib/fbe/over'
+require_relative '../test__helper'
+
+# Test.
+class TestOver < Fbe::Test
+  def test_simple
+    refute(Fbe.over?(global: {}, options: Judges::Options.new({ 'testing' => true }), loog: Loog::NULL))
+  end
+
+  def test_check_off_quota_enabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true })
+    loog = Loog::NULL
+    Fbe.octo(loog:, options:, global:).stub(:off_quota?, true) do
+      assert(Fbe.over?(global:, options:, loog:, quota_aware: true))
+    end
+  end
+
+  def test_check_off_quota_disabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true })
+    loog = Loog::NULL
+    Fbe.octo(loog:, options:, global:).stub(:off_quota?, true) do
+      refute(Fbe.over?(global:, options:, loog:, quota_aware: false))
+    end
+  end
+
+  def test_check_lifetime_enabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true, 'lifetime' => 100 })
+    loog = Loog::NULL
+    assert(Fbe.over?(global:, options:, loog:, epoch: Time.now - 120, lifetime_aware: true))
+  end
+
+  def test_check_lifetime_disabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true, 'lifetime' => 100 })
+    loog = Loog::NULL
+    refute(Fbe.over?(global:, options:, loog:, epoch: Time.now - 120, lifetime_aware: false))
+  end
+
+  def test_check_timeout_enabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true, 'timeout' => 100 })
+    loog = Loog::NULL
+    assert(Fbe.over?(global:, options:, loog:, kickoff: Time.now - 120, timeout_aware: true))
+  end
+
+  def test_check_timeout_disabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true, 'timeout' => 100 })
+    loog = Loog::NULL
+    refute(Fbe.over?(global:, options:, loog:, kickoff: Time.now - 120, timeout_aware: false))
+  end
+end


### PR DESCRIPTION
Closes #322 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified stop logic ensures runs automatically halt when nearing quota, lifetime, or timeout limits.
  - Clearer log messages when processing stops, including reasons and context.
- Bug Fixes
  - More consistent and predictable stopping behavior across loops and repositories.
- Refactor
  - Consolidated multiple guard checks into a single centralized check for improved maintainability and performance.
- Tests
  - Added comprehensive tests covering quota, lifetime, and timeout scenarios to validate stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->