### PR TITLE
#325: catch `Fbe::OffQuota` exception correctly

### DIFF
--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -214,6 +214,9 @@ class Fbe::Conclude
     end
     @loog.debug("Found and processed #{passed} facts by: #{@query}")
     passed
+  rescue Fbe::OffQuota => e
+    @loog.info(e.message)
+    passed
   end
 
   # Populates a new fact based on a previous fact and a processing block.

--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -337,5 +337,7 @@ class Fbe::Iterate
       Fbe.overwrite(f, @label, before[repo], fb: @fb)
     end
     @loog.debug("Finished scanning #{repos.size} repos in #{@kickoff.ago}: #{seen.map { |k, v| "#{k}:#{v}" }.joined}")
+  rescue Fbe::OffQuota => e
+    @loog.info(e.message)
   end
 end

--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -326,18 +326,21 @@ class Fbe::Iterate
         break
       end
     end
-    repos.each do |repo|
-      next if before[repo] == starts[repo]
-      f =
-        Fbe.if_absent(fb: @fb, always: true) do |n|
-          n.what = 'iterate'
-          n.where = 'github'
-          n.repository = repo
-        end
-      Fbe.overwrite(f, @label, before[repo], fb: @fb)
-    end
     @loog.debug("Finished scanning #{repos.size} repos in #{@kickoff.ago}: #{seen.map { |k, v| "#{k}:#{v}" }.joined}")
   rescue Fbe::OffQuota => e
     @loog.info(e.message)
+  ensure
+    if defined?(repos) && defined?(before) && defined?(starts)
+      repos.each do |repo|
+        next if before[repo] == starts[repo]
+        f =
+          Fbe.if_absent(fb: @fb, always: true) do |n|
+            n.what = 'iterate'
+            n.where = 'github'
+            n.repository = repo
+          end
+        Fbe.overwrite(f, @label, before[repo], fb: @fb)
+      end
+    end
   end
 end

--- a/test/fbe/test_iterate.rb
+++ b/test/fbe/test_iterate.rb
@@ -427,4 +427,36 @@ class TestIterate < Fbe::Test
     assert_equal(5, fb.query('(and (eq what "judge") (exists prop3))').each.to_a.size)
     assert_equal(10, fb.query('(eq what "iterate")').each.to_a.first.marker)
   end
+
+  def test_catch_fbe_off_quota_exception_correctly
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":103}}', headers: { 'X-RateLimit-Remaining' => '103' } }
+    )
+    stub_request(:get, 'https://api.github.com/repos/foo/bar').to_return(
+      body: { id: 42 }.to_json, headers: { 'Content-Type': 'application/json' }
+    ).times(3).then.to_raise(StandardError.new('No more https://api.github.com/repos/foo/bar'))
+    stub_request(:get, 'https://api.github.com/repos/foo/baz').to_return(
+      body: { id: 43 }.to_json, headers: { 'Content-Type': 'application/json' }
+    ).times(1000).then.to_raise(StandardError.new('No more https://api.github.com/repos/foo/baz'))
+    global = {}
+    loog = Loog::NULL
+    options = Judges::Options.new(['repositories=foo/bar'])
+    octo = Fbe.octo(options:, global:, loog:)
+    fb = Fbe.fb(fb: Factbase.new, global:, options:, loog:)
+    fb.insert.foo = 42
+    count = 0
+    Fbe.iterate(fb:, loog:, global:, options:, epoch: Time.now, kickoff: Time.now) do
+      as 'marker'
+      by '(agg (always) (max foo))'
+      over do |_repository, foo|
+        1000.times do
+          octo.repository('foo/baz')
+          count += 1
+        end
+        foo
+      end
+    end
+    assert_equal(51, count)
+  end
 end


### PR DESCRIPTION
Closes #325 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Gracefully handle external quota/rate-limit exhaustion: errors are logged, processing halts cleanly, and work completed so far is preserved; iteration cleanup now runs conditionally to avoid leaving partial state.
- Tests
  - Added tests that simulate quota exhaustion to verify logging, graceful termination, and accurate preservation of processed counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->