### PR TITLE
judges-action#1037: make accept many repos in `Fbe::Graph#total_commits`

### DIFF
--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -107,8 +107,24 @@ class TestGitHubGraph < Fbe::Test
     global = {}
     options = Judges::Options.new
     g = Fbe.github_graph(options:, loog: Loog::NULL, global:)
-    result = g.total_commits('zerocracy', 'baza', 'master')
+    result = g.total_commits('zerocracy', 'baza.rb', 'master')
     assert_predicate(result, :positive?)
+    g.total_commits(
+      repos: [
+        %w[zerocracy fbe master],
+        %w[zerocracy judges-action master]
+      ]
+    ).each do |h|
+      h = h.transform_keys(&:to_sym)
+      assert_pattern do
+        h => {
+          owner: String,
+          name: String,
+          branch: String,
+          total_commits: 1..
+        }
+      end
+    end
   end
 
   def test_get_fake_empty_conversations
@@ -138,6 +154,22 @@ class TestGitHubGraph < Fbe::Test
     WebMock.disable_net_connect!
     graph = Fbe.github_graph(options: Judges::Options.new('testing' => true), loog: Loog::NULL, global: {})
     assert_equal(1484, graph.total_commits('zerocracy', 'fbe', 'master'))
+    graph.total_commits(
+      repos: [
+        %w[zerocracy fbe master],
+        %w[zerocracy judges-action master]
+      ]
+    ).each do |h|
+      h = h.transform_keys(&:to_sym)
+      assert_pattern do
+        h => {
+          owner: String,
+          name: String,
+          branch: String,
+          total_commits: 1484
+        }
+      end
+    end
   end
 
   def test_fake_issue_type_event


### PR DESCRIPTION
Need for https://github.com/zerocracy/judges-action/issues/1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - total_commits now supports querying multiple repositories in one call, returning per-repo results while preserving single-repo behavior.
  - Mock/fake implementation updated to mirror multi-repo behavior (returns 1484 for single-repo, array of per-repo hashes for multi-repo).
- Bug Fixes
  - Input validation added to prevent mixing single- and multi-repo parameters.
- Documentation
  - Usage examples updated to show multi-repo query format and outputs.
- Tests
  - Added/updated tests covering multi-repo responses and adjusted single-repo expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->