### PR TITLE
#1155: fix user property in `Fbe::FakeOctokit#issue` and `Fbe::FakeOctokit#list_issues`

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -734,6 +734,7 @@ class Fbe::FakeOctokit
         repo: {
           full_name: repo
         },
+        user: { login: 'yegor256', id: 526_301, type: 'User' },
         pull_request: {
           merged_at: nil
         },

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -463,6 +463,18 @@ class TestOcto < Fbe::Test
         }
       end
     end
+    o.list_issues('foo/bazz').slice(1..).each do |issue|
+      assert_pattern do
+        issue => {
+          id: Integer,
+          number: Integer,
+          repo: { full_name: String },
+          user: { id: Integer },
+          pull_request: Hash,
+          created_at: Time
+        }
+      end
+    end
   end
 
   def test_fake_respond_to_auto_paginate


### PR DESCRIPTION
This PR fix error in [judges-action](https://github.com/zerocracy/judges-action/actions/runs/18920537012/job/54015193333?pr=1166#step:6:1530):
```
 D: Inserted new fact #10 in 258μs
D: Set 'issue' to 42 (Integer)
D: Set 'what' to "pull-was-opened" (String)
D: Set 'repository' to 2350 (Integer)
D: Set 'where' to "github" (String)
D: Set 'when' to 2024-09-20T19:00:00Z (Time)
E: RuntimeError: The value of 'who' can't be nil
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/fact.rb:56:in 'block in <class:Fact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::Fact#method_missing'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/tallied.rb:72:in 'block in <class:Fact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::Tallied::Fact#method_missing'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/rules.rb:84:in 'block in <class:Fact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::Rules::Fact#method_missing'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/tallied.rb:72:in 'block in <class:Fact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::Tallied::Fact#method_missing'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/cached/cached_fact.rb:30:in 'block in <class:CachedFact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::CachedFact#method_missing'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/indexed/indexed_fact.rb:30:in 'block in <class:IndexedFact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::IndexedFact#method_missing'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/logged.rb:112:in 'block in <class:Fact>'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'BasicObject#instance_exec'
   	/usr/local/bundle/gems/others-0.1.1/lib/others.rb:57:in 'Factbase::Logged::Fact#method_missing'
   	/action/judges/find-earliest-issue/find-earliest-issue.rb:33:in 'block (3 levels) in <top (required)>'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/impatient.rb:39:in 'block in Factbase::Impatient#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/logged.rb:55:in 'block in Factbase::Logged#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/sync/sync_factbase.rb:54:in 'block in Factbase::SyncFactbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/indexed/indexed_factbase.rb:61:in 'block in Factbase::IndexedFactbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/cached/cached_factbase.rb:61:in 'block in Factbase::CachedFactbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/pre.rb:42:in 'block in Factbase::Pre#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/rules.rb:54:in 'block in Factbase::Rules#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/tallied.rb:43:in 'block (2 levels) in Factbase::Tallied#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/tallied.rb:42:in 'Kernel#catch'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/tallied.rb:42:in 'block in Factbase::Tallied#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase.rb:184:in 'block (2 levels) in Factbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase.rb:183:in 'Kernel#catch'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase.rb:183:in 'block in Factbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase.rb:180:in 'Kernel#catch'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase.rb:180:in 'Factbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/tallied.rb:41:in 'Factbase::Tallied#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/rules.rb:52:in 'Factbase::Rules#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/pre.rb:41:in 'Factbase::Pre#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/cached/cached_factbase.rb:60:in 'Factbase::CachedFactbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/indexed/indexed_factbase.rb:60:in 'Factbase::IndexedFactbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/sync/sync_factbase.rb:53:in 'Factbase::SyncFactbase#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/logged.rb:53:in 'Factbase::Logged#txn'
   	/usr/local/bundle/gems/factbase-0.16.8/lib/factbase/impatient.rb:38:in 'Factbase::Impatient#txn'
   	/action/judges/find-earliest-issue/find-earliest-issue.rb:23:in 'block (2 levels) in <top (required)>'
   	/usr/local/bundle/gems/fbe-0.41.2/lib/fbe/iterate.rb:313:in 'block (2 levels) in Fbe::Iterate#over'
   	/usr/local/bundle/gems/fbe-0.41.2/lib/fbe/iterate.rb:278:in 'Array#each'
   	/usr/local/bundle/gems/fbe-0.41.2/lib/fbe/iterate.rb:278:in 'block in Fbe::Iterate#over'
   	<internal:kernel>:168:in 'Kernel#loop'
   	/usr/local/bundle/gems/fbe-0.41.2/lib/fbe/iterate.rb:270:in 'Fbe::Iterate#over'
   	/action/judges/find-earliest-issue/find-earliest-issue.rb:15:in 'block in <top (required)>'
   	/usr/local/bundle/gems/fbe-0.41.2/lib/fbe/iterate.rb:50:in 'BasicObject#instance_eval'
   	/usr/local/bundle/gems/fbe-0.41.2/lib/fbe/iterate.rb:50:in 'Fbe.iterate'
   	/action/judges/find-earliest-issue/find-earliest-issue.rb:12:in '<top (required)>'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judge.rb:79:in 'Kernel#load'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judge.rb:79:in 'block in Judges::Judge#run'
   	/usr/local/bundle/gems/elapsed-0.2.0/lib/elapsed.rb:45:in 'Object#elapsed'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judge.rb:78:in 'Judges::Judge#run'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:239:in 'block in Judges::Update#one_judge'
   	/usr/local/bundle/gems/timeout-0.4.4/lib/timeout.rb:188:in 'block in Timeout.timeout'
   	/usr/local/bundle/gems/timeout-0.4.4/lib/timeout.rb:38:in 'Timeout::Error.handle_timeout'
   	/usr/local/bundle/gems/timeout-0.4.4/lib/timeout.rb:197:in 'Timeout.timeout'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:238:in 'Judges::Update#one_judge'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:198:in 'block (3 levels) in Judges::Update#cycle'
   	/usr/local/bundle/gems/elapsed-0.2.0/lib/elapsed.rb:45:in 'Object#elapsed'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:197:in 'block (2 levels) in Judges::Update#cycle'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judges.rb:120:in 'block in Judges::Judges#each_with_index'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judges.rb:106:in 'Array#each'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judges.rb:106:in 'Judges::Judges#each'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/judges.rb:119:in 'Judges::Judges#each_with_index'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:182:in 'block in Judges::Update#cycle'
   	/usr/local/bundle/gems/elapsed-0.2.0/lib/elapsed.rb:45:in 'Object#elapsed'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:180:in 'Judges::Update#cycle'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:111:in 'block (2 levels) in Judges::Update#loop_them'
   	<internal:kernel>:168:in 'Kernel#loop'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:101:in 'block in Judges::Update#loop_them'
   	/usr/local/bundle/gems/elapsed-0.2.0/lib/elapsed.rb:45:in 'Object#elapsed'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:100:in 'Judges::Update#loop_them'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:74:in 'block in Judges::Update#run'
   	/usr/local/bundle/gems/timeout-0.4.4/lib/timeout.rb:188:in 'block in Timeout.timeout'
   	/usr/local/bundle/gems/timeout-0.4.4/lib/timeout.rb:38:in 'Timeout::Error.handle_timeout'
   	/usr/local/bundle/gems/timeout-0.4.4/lib/timeout.rb:197:in 'Timeout.timeout'
   	/usr/local/bundle/gems/judges-0.55.0/lib/judges/commands/update.rb:73:in 'Judges::Update#run'
   	/usr/local/bundle/gems/judges-0.55.0/bin/judges:30:in 'block in JudgesGLI.run_it'
   	/usr/local/bundle/gems/gli-2.22.2/lib/gli/command_support.rb:131:in 'GLI::CommandSupport#execute'
   	/usr/local/bundle/gems/gli-2.22.2/lib/gli/app_support.rb:298:in 'block in GLI::AppSupport#call_command'
   	/usr/local/bundle/gems/gli-2.22.2/lib/gli/app_support.rb:311:in 'GLI::AppSupport#call_command'
   	/usr/local/bundle/gems/gli-2.22.2/lib/gli/app_support.rb:85:in 'GLI::AppSupport#run'
   	/usr/local/bundle/gems/judges-0.55.0/bin/judges:285:in '<top (required)>'
   	/usr/local/bundle/bin/judges:25:in 'Kernel#load'
   	/usr/local/bundle/bin/judges:25:in '<top (required)>'
   	/usr/local/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Kernel.load'
   	/usr/local/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
   	/usr/local/lib/ruby/3.4.0/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
   	/usr/local/lib/ruby/3.4.0/bundler/cli.rb:452:in 'Bundler::CLI#exec'
   	/usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
   	/usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
   	/usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
   	/usr/local/lib/ruby/3.4.0/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
   	/usr/local/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
   	/usr/local/lib/ruby/3.4.0/bundler/cli.rb:29:in 'Bundler::CLI.start'
   	/usr/local/lib/ruby/gems/3.4.0/gems/bundler-2.6.9/exe/bundle:28:in 'block in <top (required)>'
   	/usr/local/lib/ruby/3.4.0/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
   	/usr/local/lib/ruby/gems/3.4.0/gems/bundler-2.6.9/exe/bundle:20:in '<top (required)>'
   	/usr/local/bin/bundle:25:in 'Kernel#load'
   	/usr/local/bin/bundle:25:in '<main>'
```
A similar problem is currently observed in other pull requests:
* https://github.com/zerocracy/judges-action/actions/runs/18919053552/job/54010039045?pr=1167#step:6:1359
* https://github.com/zerocracy/judges-action/actions/runs/18899734886/job/53944268769?pr=1165#step:6:1001
* https://github.com/zerocracy/judges-action/actions/runs/18871304068/job/53850173453?pr=1145#step:6:1124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced mock issue payloads to include complete user field data.
  * Expanded test assertions to validate additional issue fields including user information and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->