### PR TITLE
#1155: fix `Fbe::FakeOctokit#issue` for `fix-missing-who` judge

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -693,6 +693,18 @@ class Fbe::FakeOctokit
   #   # => {:id=>42, :number=>42, :created_at=>...}
   def issue(repo, number)
     case number
+    when 94
+      {
+        id: 42,
+        number:,
+        repo: {
+          full_name: repo
+        },
+        pull_request: {
+          merged_at: nil
+        },
+        created_at: Time.parse('2024-09-20 19:00:00 UTC')
+      }
     when 142
       {
         id: 655,

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -424,6 +424,21 @@ class TestOcto < Fbe::Test
     end
   end
 
+  def test_fetch_fake_issue_without_user
+    o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new({ 'testing' => true }))
+    result = o.issue('yegor256/test', 94)
+    refute_includes(result.keys, :user)
+    assert_pattern do
+      result => {
+        id: Integer,
+        number: 94,
+        repo: Hash,
+        pull_request: Hash,
+        created_at: Time
+      }
+    end
+  end
+
   def test_fetch_fake_pull_request
     o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new({ 'testing' => true }))
     o.pull_request('yegor256/test', 29).then do |pr|


### PR DESCRIPTION
This PR fix error in [judges-action](https://github.com/zerocracy/judges-action/actions/runs/18933330412/job/54054349740?pr=1166#step:6:336):
```
RuntimeError: fix-missing-who/stale-who doesn't match '/fb/f[stale]':
<?xml version="1.0" encoding="UTF-8"?>
<fb version="0.16.8" size="125">
  <f>
    <issue t="I">94</issue>
    <repository t="I">695</repository>
    <what t="S">pull-was-opened</what>
    <where t="S">github</where>
    <who t="I">526301</who>
  </f>
</fb>
```
A similar problem is currently observed in other pull requests:
* https://github.com/zerocracy/judges-action/actions/runs/18930367271/job/54045993997?pr=1167#step:6:331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for issue retrieval workflows with improved validation of response formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->