### PR TITLE
#375: update minitest gem to 6.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'minitest', '~>5.25', require: false
+gem 'minitest', '~>6.0', require: false
+gem 'minitest-mock', '~>5.27', require: false
 gem 'minitest-reporters', '~>1.7', require: false
 gem 'minitest-stub-const', '~>0.6', require: false
 gem 'os', '~>1.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,9 @@ GEM
     logger (1.7.0)
     loog (0.6.1)
       logger (~> 1.0)
-    minitest (5.27.0)
+    minitest (6.0.0)
+      prism (~> 1.5)
+    minitest-mock (5.27.0)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -278,7 +280,8 @@ PLATFORMS
 
 DEPENDENCIES
   fbe!
-  minitest (~> 5.25)
+  minitest (~> 6.0)
+  minitest-mock (~> 5.27)
   minitest-reporters (~> 1.7)
   minitest-stub-const (~> 0.6)
   os (~> 1.1)

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -34,6 +34,7 @@ Minitest.load :minitest_reporter
 
 require 'loog'
 require 'minitest/autorun'
+require 'minitest/mock'
 require 'minitest/stub_const'
 require 'webmock/minitest'
 require_relative '../lib/fbe'


### PR DESCRIPTION
Following from [minitest changelog](https://github.com/minitest/minitest/blob/5bbab5cc4e99fd2b43ecdd386c7dc81f2db5072c/History.rdoc):

> Dropped minitest/mock.rb. This has been extracted to the minitest-mock gem.

We just need to add and require [`minitest-mock`](https://github.com/minitest/minitest-mock) gem.


Closes #375 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded minitest dependency to version 6.0
  * Added minitest-mock dependency

* **Tests**
  * Enhanced test infrastructure with mocking support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->