### PR TITLE
Fix #428: Fall back to default in Fbe.regularly when PMP lacks p_since_days

### DIFF
--- a/lib/fbe/regularly.rb
+++ b/lib/fbe/regularly.rb
@@ -55,7 +55,7 @@ def Fbe.regularly(area, p_every_days, p_since_days = nil, fb: Fbe.fb, judge: $ju
     f.what = judge
     f.when = Time.now
     unless p_since_days.nil?
-      days = pmp.nil? ? 28 : pmp[p_since_days].first
+      days = pmp.nil? || pmp[p_since_days].nil? ? 28 : pmp[p_since_days].first
       since = Time.now - (days * 24 * 60 * 60)
       f.since = since
     end

--- a/test/fbe/test_regularly.rb
+++ b/test/fbe/test_regularly.rb
@@ -34,4 +34,23 @@ class TestRegularly < Fbe::Test
     end
     assert_equal(0, fb.size)
   end
+
+  def test_uses_default_since_days_when_pmp_lacks_property
+    fb = Factbase.new
+    fb.txn do |fbt|
+      f = fbt.insert
+      f.what = 'pmp'
+      f.area = 'quality'
+      f.interval = 3
+    end
+    loog = Loog::NULL
+    judge = 'test'
+    Fbe.regularly('quality', 'interval', 'days', fb:, loog:, judge:) do |f|
+      f.foo = 42
+    end
+    assert_equal(2, fb.size)
+    fact = fb.query("(eq what '#{judge}')").each.first
+    refute_nil(fact)
+    refute_nil(fact.since)
+  end
 end


### PR DESCRIPTION
@yegor256 this PR fixes #428.

## What was wrong

`Fbe.regularly` raised `NoMethodError: undefined method 'first' for nil` at `lib/fbe/regularly.rb:58` when a PMP fact existed in the factbase with the `p_every_days` property but **without** the `p_since_days` property.

The query at line 38 only filters by `(exists #{p_every_days})`, so `pmp` could be non-nil while still lacking `p_since_days`. In that case `pmp[p_since_days]` returns `nil`, and `nil.first` blows up. The original `pmp.nil? ? 28 : pmp[p_since_days].first` only protected against the entire PMP fact being missing, not against the individual property being missing.

## What I changed

- `lib/fbe/regularly.rb` — extended the existing `pmp.nil?` guard so the default of 28 days is also used when `pmp[p_since_days]` is `nil`. The change is one line: `pmp.nil? ? 28 : pmp[p_since_days].first` → `pmp.nil? || pmp[p_since_days].nil? ? 28 : pmp[p_since_days].first`.
- `test/fbe/test_regularly.rb` — added `test_uses_default_since_days_when_pmp_lacks_property`, which inserts a PMP fact with `interval` but not `days`, then runs `Fbe.regularly('quality', 'interval', 'days', ...)` and verifies the block runs and the resulting fact has `since` populated. This test reproduces the issue exactly (it fails with the same `NoMethodError` at `regularly.rb:58` on master) and passes after the fix.

## Verification

- New test fails on master with the reported `NoMethodError`, passes with the fix.
- All 248 existing tests still pass (`bundle exec rake test`).
- `rubocop` is clean on the touched files.
- All 10 CI checks are green.

Ready for merge.
