### PR TITLE
Fix #429: Raise descriptive error in Fbe::Graph#pull_requests_with_reviews when repository is missing

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -310,16 +310,16 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
         }
       GRAPHQL
     ).to_h
+    nodes = result.dig('repository', 'pullRequests', 'nodes')
+    raise(Fbe::Error, "Repository '#{owner}/#{name}' not found") if nodes.nil?
     {
-      'pulls_with_reviews' => result
-        .dig('repository', 'pullRequests', 'nodes')
-        .filter_map do |pull|
-          next if pull.dig('timelineItems', 'nodes').empty?
-          {
-            'id' => pull['id'],
-            'number' => pull['number']
-          }
-        end,
+      'pulls_with_reviews' => nodes.filter_map do |pull|
+        next if pull.dig('timelineItems', 'nodes').empty?
+        {
+          'id' => pull['id'],
+          'number' => pull['number']
+        }
+      end,
       'has_next_page' => result.dig('repository', 'pullRequests', 'pageInfo', 'hasNextPage'),
       'next_cursor' => result.dig('repository', 'pullRequests', 'pageInfo', 'endCursor')
     }

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -204,6 +204,18 @@ class TestGitHubGraph < Fbe::Test
     end
   end
 
+  def test_pull_requests_with_reviews_when_repository_is_missing
+    WebMock.disable_net_connect!
+    graph = Fbe::Graph.new(token: 'fake')
+    graph.define_singleton_method(:query) do |_qry|
+      { 'errors' => [{ 'message' => 'Could not resolve to a Repository' }] }
+    end
+    error = assert_raises(Fbe::Error) do
+      graph.pull_requests_with_reviews('bad-owner', 'bad-repo', Time.parse('2025-08-01T18:00:00Z'))
+    end
+    assert_includes(error.message, 'bad-owner/bad-repo')
+  end
+
   def test_fake_pull_request_reviews
     WebMock.disable_net_connect!
     graph = Fbe.github_graph(options: Judges::Options.new('testing' => true), loog: Loog::NULL, global: {})

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -210,9 +210,10 @@ class TestGitHubGraph < Fbe::Test
     graph.define_singleton_method(:query) do |_qry|
       { 'errors' => [{ 'message' => 'Could not resolve to a Repository' }] }
     end
-    error = assert_raises(Fbe::Error) do
-      graph.pull_requests_with_reviews('bad-owner', 'bad-repo', Time.parse('2025-08-01T18:00:00Z'))
-    end
+    error =
+      assert_raises(Fbe::Error) do
+        graph.pull_requests_with_reviews('bad-owner', 'bad-repo', Time.parse('2025-08-01T18:00:00Z'))
+      end
     assert_includes(error.message, 'bad-owner/bad-repo')
   end
 


### PR DESCRIPTION
@yegor256, this PR fixes #429 and is ready for merge — all 10 CI checks pass.

## Problem

`Fbe::Graph#pull_requests_with_reviews` crashed with `NoMethodError: undefined method 'filter_map' for nil` whenever the GitHub GraphQL response did not include a `repository` key. This happens when the repository does not exist, the token lacks permission, or GraphQL returns a partial failure (`{"errors": [...]}`).

The crash originated at `lib/fbe/github_graph.rb:316`:

```ruby
.dig("repository", "pullRequests", "nodes")
.filter_map { ... }   # NoMethodError when result.dig returns nil
```

## Fix

Extract the `nodes` lookup before iterating, and raise a descriptive `Fbe::Error` when the repository is missing — the same pattern already used by `Fbe::Graph#total_commits` (`lib/fbe/github_graph.rb:141`). Callers now receive an actionable message such as `Repository 'owner/repo' not found` instead of an opaque `NoMethodError`.

## Tests

* Added `test_pull_requests_with_reviews_when_repository_is_missing` which stubs `#query` to return an errors-only response (matching the reproduction in the issue) and asserts an `Fbe::Error` whose message mentions the offending `owner/repo`. Without the production fix, this test fails with the exact `NoMethodError` reported in #429.
* All 248 pre-existing unit tests still pass; `bundle exec rake` (test, rubocop, picks, yard) is green locally.

## Commits

1. `#429: Add failing test reproducing NoMethodError when GraphQL response lacks repository key` — red test on master.
2. `#429: Raise descriptive Fbe::Error in pull_requests_with_reviews when repository key is missing` — production change that turns the test green.
