### PR TITLE
#434: Detect GraphQL errors centrally in Fbe::Graph#query

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -45,6 +45,10 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
   #   puts result.viewer.login #=> "octocat"
   def query(qry)
     result = client.query(client.parse(qry))
+    if result.respond_to?(:errors) && !result.errors.empty?
+      msgs = result.errors.respond_to?(:messages) ? result.errors.messages.values.flatten : [result.errors.to_s]
+      raise(Fbe::Error, "GraphQL query failed: #{msgs.join('; ')}")
+    end
     result.data
   end
 
@@ -179,8 +183,8 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
       GRAPHQL
     ).to_h
     {
-      'issues' => result.dig('repository', 'issues', 'totalCount') || 0,
-      'pulls' => result.dig('repository', 'pullRequests', 'totalCount') || 0
+      'issues' => result.dig('repository', 'issues', 'totalCount'),
+      'pulls' => result.dig('repository', 'pullRequests', 'totalCount')
     }
   end
 
@@ -311,7 +315,6 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
       GRAPHQL
     ).to_h
     nodes = result.dig('repository', 'pullRequests', 'nodes')
-    raise(Fbe::Error, "Repository '#{owner}/#{name}' not found") if nodes.nil?
     {
       'pulls_with_reviews' => nodes.filter_map do |pull|
         next if pull.dig('timelineItems', 'nodes').empty?
@@ -504,7 +507,7 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
         GRAPHQL
       ).to_h
       releases = result.dig('repository', 'releases', 'nodes')
-      break if releases.nil? || releases.empty?
+      break if releases.empty?
       total += releases.count { !_1['isDraft'] && _1['publishedAt'] && Time.parse(_1['publishedAt']) > since }
       break if releases.all? { _1['publishedAt'] && Time.parse(_1['publishedAt']) < since }
       break unless result.dig('repository', 'releases', 'pageInfo', 'hasNextPage')

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -206,10 +206,19 @@ class TestGitHubGraph < Fbe::Test
 
   def test_pull_requests_with_reviews_when_repository_is_missing
     WebMock.disable_net_connect!
-    graph = Fbe::Graph.new(token: 'fake')
-    graph.define_singleton_method(:query) do |_qry|
-      { 'errors' => [{ 'message' => 'Could not resolve to a Repository' }] }
+    errors = Object.new
+    errors.define_singleton_method(:empty?) { false }
+    errors.define_singleton_method(:messages) do
+      { 'data' => ["Could not resolve to a Repository with the name 'bad-owner/bad-repo'."] }
     end
+    response = Object.new
+    response.define_singleton_method(:errors) { errors }
+    response.define_singleton_method(:data) { nil }
+    fake_client = Object.new
+    fake_client.define_singleton_method(:parse) { |qry| qry }
+    fake_client.define_singleton_method(:query) { |_parsed| response }
+    graph = Fbe::Graph.new(token: 'fake')
+    graph.define_singleton_method(:client) { fake_client }
     error =
       assert_raises(Fbe::Error) do
         graph.pull_requests_with_reviews('bad-owner', 'bad-repo', Time.parse('2025-08-01T18:00:00Z'))
@@ -271,5 +280,25 @@ class TestGitHubGraph < Fbe::Test
         releases: 7
       }
     end
+  end
+
+  def test_query_raises_when_graphql_response_has_errors
+    WebMock.disable_net_connect!
+    errors = Object.new
+    errors.define_singleton_method(:empty?) { false }
+    errors.define_singleton_method(:messages) do
+      { 'data' => ["Could not resolve to a Repository with the name 'bad-owner/bad-repo'."] }
+    end
+    response = Object.new
+    response.define_singleton_method(:errors) { errors }
+    response.define_singleton_method(:data) { nil }
+    fake_client = Object.new
+    fake_client.define_singleton_method(:parse) { |qry| qry }
+    fake_client.define_singleton_method(:query) { |_parsed| response }
+    graph = Fbe::Graph.new(token: 'fake')
+    graph.define_singleton_method(:client) { fake_client }
+    err = assert_raises(Fbe::Error) { graph.query('{ viewer { login } }') }
+    assert_includes(err.message, 'GraphQL query failed')
+    assert_includes(err.message, 'bad-owner/bad-repo')
   end
 end


### PR DESCRIPTION
Per your "definitely the third option" reply on #434 — fixes the GraphQL error detection at the `query()` level instead of per-method.

`Fbe::Graph#query` was returning `result.data` without checking `result.errors`. When GitHub responds with a top-level `{"errors": [...]}` (token without access, repo deleted, etc.), `data` is `nil`, leading to silent zeros (`|| 0` in 4 methods) or downstream `NoMethodError` (the case #429 patched per-method).

Now `query()` raises `Fbe::Error` with the joined error messages whenever `result.errors` is non-empty. Per-method guards that protected against the same condition are removed:

- `pull_requests_with_reviews` — `raise if nodes.nil?` from #433
- `total_issues_and_pulls` — `|| 0` fallbacks (totalCount is `Int!`)
- `total_releases_published` — `releases.nil?` half of the break

Two guards are kept because they protect against legitimate non-error nulls (different concern from #434):

- `total_commits_pushed` — `defaultBranchRef` is null on a repo with no commits
- `resolved_conversations` — `pullRequest` is null when the PR doesn't exist

The existing test for the missing-repository case is updated to stub the GraphQL client (so the central check actually runs) instead of overriding `query()` itself.

Closes #434