### PR TITLE
#350: Fix double-escaped apostrophe in bad-branch-name-was-punished bylaw

### DIFF
--- a/assets/bylaws/bad-branch-name-was-punished.fe.liquid
+++ b/assets/bylaws/bad-branch-name-was-punished.fe.liquid
@@ -1,5 +1,5 @@
 (award
-  (explain "If a branch has a name that doesn\\\'t obey the convention, a penalty is given to the author")
+  (explain "If a branch has a name that doesn\'t obey the convention, a penalty is given to the author")
   (aka
     (let fee {{ -6 | times: anger }})
     (give fee "as a basis")

--- a/test/fbe/test_bylaws.rb
+++ b/test/fbe/test_bylaws.rb
@@ -19,6 +19,17 @@ class TestBylaws < Fbe::Test
     refute_nil(laws['published-release-was-rewarded'])
   end
 
+  def test_apostrophes_are_not_double_escaped
+    Fbe.bylaws.each do |title, formula|
+      markdown = Fbe::Award.new(formula).bylaw.markdown
+      refute_match(
+        /\\'/,
+        markdown,
+        "Bylaw #{title.inspect} contains a backslash-escaped apostrophe in: #{markdown.inspect}"
+      )
+    end
+  end
+
   def test_check_all_bills
     awards = {
       'published-release-was-rewarded' => {


### PR DESCRIPTION
@yegor256 this PR fixes #350 — the bylaws page rendered `doesn\\'t` (backslash + apostrophe) instead of `doesn't`.

## Root cause

`assets/bylaws/bad-branch-name-was-punished.fe.liquid` stored the explain string with three backslashes before the apostrophe:

```
(explain "If a branch has a name that doesn\\\'t obey the convention, …")
```

Liquid passes the raw bytes through unchanged. `Factbase::Syntax` (`factbase-0.19.9/lib/factbase/syntax.rb`) then tokenises double-quoted literals and consumes exactly **one** backslash that precedes a quote character, leaving `doesn\\'t` (two backslashes + apostrophe) inside the parsed S-expression. That string is then formatted into the bylaw's markdown, which is what shows up on the vitals page.

Since the tokenizer only needs a single backslash to escape an apostrophe inside a double-quoted token, the template only needed `\'` rather than `\\\'`.

## Changes

1. **`test/fbe/test_bylaws.rb`** — new `test_apostrophes_are_not_double_escaped` walks every bylaw, renders the markdown, and asserts `/\\'/` does not match. Before the fix it failed only on `bad-branch-name-was-punished`; after the fix it passes for all 10 bylaws.
2. **`assets/bylaws/bad-branch-name-was-punished.fe.liquid`** — change `doesn\\\'t` to `doesn\'t`. The rendered markdown is now `If a branch has a name that doesn't obey the convention, …`.

## Verification

- `bundle exec rake` (test + rubocop + picks + yard) passes locally on Ruby 3.3.6.
- All 10 CI checks are green: actionlint, copyrights, markdown-lint, pdd, rake (ubuntu-24.04, 3.3), rake (macos-15, 3.3), reuse, typos, xcop, yamllint.
- The bill points for this bylaw are unchanged (`-12` with default `anger=2`).

The fix is intentionally minimal — only the one over-escaped string is touched; no other bylaws contain apostrophes today, but the new test will catch any future regression in any of them.