### PR TITLE
Add four GraphQL methods for migrating remaining REST `.each` call sites

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Elegant/GoodMethodName:
     - create_commit_comment
     - create_connection
     - delete_one
+    - distinct_contributors
     - dump_headers
     - extract_remaining_count
     - faraday_value
@@ -42,6 +43,7 @@ Elegant/GoodMethodName:
     - issue_comments
     - issue_events
     - issue_timeline
+    - issue_timeline_items
     - issue_type_event
     - just_one
     - kill_if
@@ -65,6 +67,8 @@ Elegant/GoodMethodName:
     - quota_unaware
     - random_time
     - rate_limit
+    - releases_count
+    - releases_in_window
     - remove_organization_membership
     - repo_id_by_name
     - repo_name_by_id

--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -513,6 +513,156 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
     { 'releases' => total }
   end
 
+  # Counts the total number of releases (including drafts and prereleases).
+  #
+  # @param [String] owner Repository owner
+  # @param [String] name Repository name
+  # @return [Hash] A hash with key 'releases' mapped to the total count
+  def releases_count(owner, name)
+    result = query(
+      <<~GRAPHQL
+        {
+          repository(owner: "#{owner}", name: "#{name}") {
+            releases { totalCount }
+          }
+        }
+      GRAPHQL
+    ).to_h
+    { 'releases' => result.dig('repository', 'releases', 'totalCount') || 0 }
+  end
+
+  # Lists non-draft releases with publishedAt within the [since, to] window.
+  #
+  # @param [String] owner Repository owner
+  # @param [String] name Repository name
+  # @param [Time] since Lower bound (inclusive)
+  # @param [Time] to Upper bound (inclusive)
+  # @return [Array<Hash>] Each item has 'tagName' (String) and 'publishedAt' (Time)
+  def releases_in_window(owner, name, since, to)
+    found = []
+    cursor = nil
+    loop do
+      result = query(
+        <<~GRAPHQL
+          {
+            repository(owner: "#{owner}", name: "#{name}") {
+              releases(first: 25, after: "#{cursor}", orderBy: { field: CREATED_AT, direction: DESC }) {
+                nodes {
+                  tagName
+                  isDraft
+                  publishedAt
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+          }
+        GRAPHQL
+      ).to_h
+      releases = result.dig('repository', 'releases', 'nodes')
+      break if releases.nil? || releases.empty?
+      releases.each do |r|
+        next if r['isDraft']
+        next unless r['publishedAt']
+        published = Time.parse(r['publishedAt'])
+        next if published > to
+        next if published < since
+        found << { 'tagName' => r['tagName'], 'publishedAt' => published }
+      end
+      break if releases.all? { _1['publishedAt'] && Time.parse(_1['publishedAt']) < since }
+      break unless result.dig('repository', 'releases', 'pageInfo', 'hasNextPage')
+      cursor = result.dig('repository', 'releases', 'pageInfo', 'endCursor')
+    end
+    found
+  end
+
+  # Lists timeline events for an issue, paginated.
+  #
+  # @param [String] owner Repository owner
+  # @param [String] name Repository name
+  # @param [Integer] issue Issue number
+  # @return [Array<Hash>] Each item has '__typename' (String) and 'id' (String GraphQL node ID)
+  def issue_timeline_items(owner, name, issue)
+    items = []
+    cursor = nil
+    loop do
+      result = query(
+        <<~GRAPHQL
+          {
+            repository(owner: "#{owner}", name: "#{name}") {
+              issue(number: #{issue}) {
+                timelineItems(first: 100, after: "#{cursor}") {
+                  nodes {
+                    __typename
+                    ... on Node { id }
+                  }
+                  pageInfo {
+                    endCursor
+                    hasNextPage
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      ).to_h
+      timeline = result.dig('repository', 'issue', 'timelineItems')
+      break if timeline.nil?
+      nodes = timeline['nodes'] || []
+      nodes.each { |n| items << { '__typename' => n['__typename'], 'id' => n['id'] } }
+      break unless timeline.dig('pageInfo', 'hasNextPage')
+      cursor = timeline.dig('pageInfo', 'endCursor')
+    end
+    items
+  end
+
+  # Returns distinct GitHub user database IDs that authored commits on the default branch.
+  #
+  # @param [String] owner Repository owner
+  # @param [String] name Repository name
+  # @return [Array<Integer>] Deduplicated databaseId values; commits without a linked GitHub user are skipped
+  def distinct_contributors(owner, name)
+    ids = []
+    cursor = nil
+    loop do
+      result = query(
+        <<~GRAPHQL
+          {
+            repository(owner: "#{owner}", name: "#{name}") {
+              defaultBranchRef {
+                target {
+                  ... on Commit {
+                    history(first: 100, after: "#{cursor}") {
+                      nodes {
+                        author { user { databaseId } }
+                      }
+                      pageInfo {
+                        endCursor
+                        hasNextPage
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      ).to_h
+      history = result.dig('repository', 'defaultBranchRef', 'target', 'history')
+      break if history.nil?
+      nodes = history['nodes'] || []
+      nodes.each do |c|
+        id = c.dig('author', 'user', 'databaseId')
+        ids << id if id
+      end
+      break unless history.dig('pageInfo', 'hasNextPage')
+      cursor = history.dig('pageInfo', 'endCursor')
+    end
+    ids.uniq
+  end
+
   private
 
   # Creates or returns a cached GraphQL client instance.
@@ -755,6 +905,29 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
 
     def total_releases_published(_owner, _name, _since)
       { 'releases' => 7 }
+    end
+
+    def releases_count(_owner, _name)
+      { 'releases' => 7 }
+    end
+
+    def releases_in_window(_owner, _name, since, to)
+      [
+        { 'tagName' => '0.0.6', 'publishedAt' => Time.parse('2025-12-16T15:00:00Z') },
+        { 'tagName' => '0.0.5', 'publishedAt' => Time.parse('2025-11-16T15:00:00Z') },
+        { 'tagName' => '0.0.4', 'publishedAt' => Time.parse('2025-10-16T15:00:00Z') }
+      ].select { |r| r['publishedAt'].between?(since, to) }
+    end
+
+    def issue_timeline_items(_owner, _name, _issue)
+      [
+        { '__typename' => 'IssueTypeAddedEvent', 'id' => 'ITAE_kwDOO0iZpc7DR0iz' },
+        { '__typename' => 'IssueTypeChangedEvent', 'id' => 'ITCE_kwDOO0iZpc7DR0i0' }
+      ]
+    end
+
+    def distinct_contributors(_owner, _name)
+      [42, 43, 526_301]
     end
 
     private

--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -921,8 +921,8 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
 
     def issue_timeline_items(_owner, _name, _issue)
       [
-        { '__typename' => 'IssueTypeAddedEvent', 'id' => 'ITAE_kwDOO0iZpc7DR0iz' },
-        { '__typename' => 'IssueTypeChangedEvent', 'id' => 'ITCE_kwDOO0iZpc7DR0i0' }
+        { '__typename' => 'IssueTypeAddedEvent', 'id' => 'ITAE_examplevq862Ga8lzwAAAAQZanzv' },
+        { '__typename' => 'IssueTypeChangedEvent', 'id' => 'ITCE_examplevq862Ga8lzwAAAAQZbq9S' }
       ]
     end
 

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -272,4 +272,53 @@ class TestGitHubGraph < Fbe::Test
       }
     end
   end
+
+  def test_fake_releases_count
+    WebMock.disable_net_connect!
+    graph = Fbe.github_graph(options: Judges::Options.new('testing' => true), loog: Loog::NULL, global: {})
+    h = graph.releases_count('foo', 'foo')
+    h = h.transform_keys(&:to_sym)
+    assert_pattern do
+      h => { releases: Integer }
+    end
+    assert_operator(h[:releases], :>, 0)
+  end
+
+  def test_fake_releases_in_window
+    WebMock.disable_net_connect!
+    graph = Fbe.github_graph(options: Judges::Options.new('testing' => true), loog: Loog::NULL, global: {})
+    since = Time.parse('2024-01-01T00:00:00Z')
+    upto = Time.parse('2030-12-31T00:00:00Z')
+    releases = graph.releases_in_window('foo', 'foo', since, upto)
+    assert_instance_of(Array, releases)
+    refute_empty(releases)
+    releases.each do |r|
+      assert_kind_of(String, r['tagName'])
+      assert_kind_of(Time, r['publishedAt'])
+      assert_operator(r['publishedAt'], :>=, since)
+      assert_operator(r['publishedAt'], :<=, upto)
+    end
+  end
+
+  def test_fake_issue_timeline_items
+    WebMock.disable_net_connect!
+    graph = Fbe.github_graph(options: Judges::Options.new('testing' => true), loog: Loog::NULL, global: {})
+    items = graph.issue_timeline_items('zerocracy', 'baza', 42)
+    assert_instance_of(Array, items)
+    refute_empty(items)
+    items.each do |item|
+      assert_kind_of(String, item['__typename'])
+      assert_kind_of(String, item['id'])
+    end
+  end
+
+  def test_fake_distinct_contributors
+    WebMock.disable_net_connect!
+    graph = Fbe.github_graph(options: Judges::Options.new('testing' => true), loog: Loog::NULL, global: {})
+    ids = graph.distinct_contributors('zerocracy', 'fbe')
+    assert_instance_of(Array, ids)
+    refute_empty(ids)
+    ids.each { |id| assert_kind_of(Integer, id) }
+    assert_equal(ids.uniq.size, ids.size, 'ids must be unique')
+  end
 end


### PR DESCRIPTION
Adds four new methods to `Fbe::Graph` plus matching `Fbe::Graph::Fake` implementations:

- `releases_count(owner, name)` — `repository.releases.totalCount`
- `releases_in_window(owner, name, since, to)` — paginated, returns `Array<{ tagName, publishedAt }>`
- `issue_timeline_items(owner, name, issue)` — paginated, returns `Array<{ __typename, id }>`
- `distinct_contributors(owner, name)` — paginated commit history, returns deduplicated `Array<Integer>` of `databaseId` values

These cover the five `Fbe.octo.X(repo).each` REST call sites flagged in zerocracy/judges-action#1347 — the same `Sawyer::Resource#each` shape trap that caused zerocracy/judges-action#1161. Migration of the call sites themselves will follow in a separate judges-action PR after this is released.

All four new methods follow the established pattern of `total_releases_published` (pagination loop with `pageInfo` cursor, string-keyed result hashes from GraphQL nodes).

Tests exercise the Fake path; live HTTP tests are not added (consistent with how the other Graph methods are tested in this file).

CI green locally: `bundle exec rake` → 0 failures, 0 errors, 0 rubocop offenses.