### PR TITLE
Mask Authorization header credentials in formatter logs (#439)

### DIFF
--- a/lib/fbe/middleware/formatter.rb
+++ b/lib/fbe/middleware/formatter.rb
@@ -39,6 +39,15 @@ require_relative '../../fbe/middleware'
 # Copyright:: Copyright (c) 2024-2026 Zerocracy
 # License:: MIT
 class Fbe::Middleware::Formatter < Faraday::Logging::Formatter
+  # Registers regex filters that mask credentials in Authorization headers
+  # before they reach the underlying logger. The Faraday::Logging::Formatter
+  # base class invokes #apply_filters on every logged string; without this
+  # override the inherited filter list is empty and tokens leak verbatim.
+  def initialize(...)
+    super
+    filter(/(Authorization:\s*"?(?:Bearer|Basic|Token))\s+[^"\s]+/i, '\1 [FILTERED]')
+  end
+
   # Captures HTTP request details for later use in error logging.
   #
   # @param [Hash] http Request data including method, url, headers, and body

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -34,12 +34,13 @@ class LoggingFormatterTest < Fbe::Test
       refute_empty(str)
       [
         %r{http://example.com},
-        /Authorization:/,
+        /Authorization: "Bearer \[FILTERED\]"/,
         %r{HTTP/1.1 401},
         /x-github-api-version-selected: "2022-11-28"/,
         /hello, world!/,
         /request body/
       ].each { |ptn| assert_match(ptn, str) }
+      refute_match(/github_pat_11AAsecret/, str)
     end
   end
 
@@ -64,13 +65,14 @@ class LoggingFormatterTest < Fbe::Test
       refute_empty(str)
       [
         %r{http://example.com},
-        /Authorization:/,
+        /Authorization: "Bearer \[FILTERED\]"/,
         /some request body/,
         %r{HTTP/1.1 502},
         /x-github-api-version-selected: "2022-11-28"/,
         %r{content-type: "text/html; charset=utf-8"},
         "#{body.slice(0, 97)}..."
       ].each { |ptn| assert_match(ptn, str) }
+      refute_match(/github_pat_11AAsecret/, str)
     end
   end
 


### PR DESCRIPTION
Fixes #439.

`Fbe::Middleware::Formatter` was logging the full `Authorization` header value, including the live `Bearer <token>`, on every 4xx/5xx response. The class docstring already promised `Authorization: "Bearer [FILTERED]"` but no `Faraday::Logging::Formatter#filter` was ever registered — `apply_filters` ran with an empty filter list and the token reached the logger verbatim.

## Fix

Override `Fbe::Middleware::Formatter#initialize` to register a regex filter that masks Bearer/Basic/Token schemes:

```ruby
def initialize(...)
  super
  filter(/(Authorization:\s*"?(?:Bearer|Basic|Token))\s+[^"\s]+/i, '\1 [FILTERED]')
end
```

The regex anchors on the literal `Authorization:` prefix (with optional whitespace and opening quote from `dump_headers`'s `inspect`), captures the auth scheme, then replaces the credential portion with `[FILTERED]`. This avoids over-matching free-form `Bearer` mentions in URL paths or response bodies.

## Test changes

The existing assertions used `assert_match(/Authorization:/, str)`, which matched both the leaked and the masked form — passing whether the token was redacted or not. Replaced with the stronger pair:

```ruby
assert_match(/Authorization: "Bearer \[FILTERED\]"/, str)
refute_match(/github_pat_11AAsecret/, str)
```

so future regressions in the masking path will be caught.

`bundle exec rake` clean locally: 5 formatter tests / 40 assertions, 0 failures; 65 files rubocop clean.