### PR TITLE
#442: Omit GraphQL after argument when cursor is nil

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -287,11 +287,12 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
   #     cursor = json['next_cursor']
   #   end
   def pull_requests_with_reviews(owner, name, since, cursor: nil)
+    after = "after: \"#{cursor}\", " unless cursor.nil?
     result = query(
       <<~GRAPHQL
         {
           repository(owner: "#{owner}", name: "#{name}") {
-            pullRequests(first: 100, after: "#{cursor}") {
+            pullRequests(#{after}first: 100) {
               nodes {
                 id
                 number
@@ -349,11 +350,12 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
   def pull_request_reviews(owner, name, pulls: [])
     requests =
       pulls.map do |number, cursor|
+        after = "after: \"#{cursor}\", " unless cursor.nil?
         <<~GRAPHQL
           pr_#{number}: pullRequest(number: #{number}) {
             id
             number
-            reviews(first: 100, after: "#{cursor}") {
+            reviews(#{after}first: 100) {
               nodes {
                 id
                 submittedAt

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -272,4 +272,30 @@ class TestGitHubGraph < Fbe::Test
       }
     end
   end
+
+  def test_pull_requests_with_reviews_omits_after_when_cursor_is_nil
+    WebMock.disable_net_connect!
+    graph = Fbe::Graph.new(token: 'fake')
+    captured = nil
+    page = { 'nodes' => [], 'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil } }
+    graph.define_singleton_method(:query) do |qry|
+      captured = qry
+      { 'repository' => { 'pullRequests' => page } }
+    end
+    graph.pull_requests_with_reviews('foo', 'bar', Time.parse('2025-08-01T18:00:00Z'), cursor: nil)
+    refute_includes(captured, 'after: ""')
+  end
+
+  def test_pull_request_reviews_omits_after_when_cursor_is_nil
+    WebMock.disable_net_connect!
+    graph = Fbe::Graph.new(token: 'fake')
+    captured = nil
+    reviews = { 'nodes' => [], 'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil } }
+    graph.define_singleton_method(:query) do |qry|
+      captured = qry
+      { 'repository' => { 'pr_2' => { 'id' => 'PR_x', 'number' => 2, 'reviews' => reviews } } }
+    end
+    graph.pull_request_reviews('foo', 'bar', pulls: [[2, nil]])
+    refute_includes(captured, 'after: ""')
+  end
 end


### PR DESCRIPTION
@yegor256 this PR fixes #442.

**The bug.** Both `pull_requests_with_reviews` (line 294) and `pull_request_reviews` (line 356) in `lib/fbe/github_graph.rb` interpolated the `cursor` value directly into the GraphQL query as `after: "#{cursor}"`. When the caller passed `cursor: nil` (for the first page), Ruby produced `after: ""` — an empty string, which is not a valid opaque cursor and is rejected/misinterpreted by the GitHub GraphQL API.

**The fix.** I mirrored the pattern already used correctly in `total_commits_pushed` (line 405): build an `after = "after: "#{cursor}", " unless cursor.nil?` snippet and interpolate it into the query. When `cursor` is `nil`, `after` is `nil` and the `after:` argument is omitted from the query entirely. When `cursor` is a real cursor, the argument is rendered as before. This required a one-line change inside each of the two methods.

**Tests.** I added two tests in `test/fbe/test_github_graph.rb` that capture the GraphQL query string sent through `Fbe::Graph#query` and assert it does not contain `after: ""` when `cursor` is `nil`. Both tests fail on `master` and pass with this change. The full test suite (`bundle exec rake test`) and `rubocop` both pass locally and in CI.

Ready for merge.
