### PR TITLE
#439: filter Authorization header from formatter logs

### DIFF
--- a/lib/fbe/middleware/formatter.rb
+++ b/lib/fbe/middleware/formatter.rb
@@ -39,6 +39,19 @@ require_relative '../../fbe/middleware'
 # Copyright:: Copyright (c) 2024-2026 Zerocracy
 # License:: MIT
 class Fbe::Middleware::Formatter < Faraday::Logging::Formatter
+  # Registers a filter that masks the credential portion of an
+  # `Authorization` header so live tokens never reach the log.
+  # Matches any auth scheme: `Authorization: "Bearer xxx"`,
+  # `Authorization: "Basic yyy"`, etc. The scheme is preserved,
+  # the credential is replaced with `[FILTERED]`.
+  #
+  # @param [Logger] logger The Faraday-supplied logger
+  # @param [Hash] options Faraday formatter options
+  def initialize(logger:, options:)
+    super
+    filter(/(Authorization:\s*"?\s*\S+\s+)[^"\s]+/i, '\1[FILTERED]')
+  end
+
   # Captures HTTP request details for later use in error logging.
   #
   # @param [Hash] http Request data including method, url, headers, and body

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -34,12 +34,13 @@ class LoggingFormatterTest < Fbe::Test
       refute_empty(str)
       [
         %r{http://example.com},
-        /Authorization:/,
+        /Authorization: "Bearer \[FILTERED\]"/,
         %r{HTTP/1.1 401},
         /x-github-api-version-selected: "2022-11-28"/,
         /hello, world!/,
         /request body/
       ].each { |ptn| assert_match(ptn, str) }
+      refute_match(/github_pat_11AAsecret/, str, 'live token must never appear in the log')
     end
   end
 
@@ -47,6 +48,22 @@ class LoggingFormatterTest < Fbe::Test
     log_it(status: 403) do |loog|
       str = loog.to_s
       refute_empty(str)
+    end
+  end
+
+  def test_filters_basic_auth_credentials_from_log
+    log_it(status: 500, request_headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' }) do |loog|
+      str = loog.to_s
+      assert_match(/Authorization: "Basic \[FILTERED\]"/, str)
+      refute_match(/dXNlcjpwYXNzd29yZA==/, str, 'Basic credentials must never appear in the log')
+    end
+  end
+
+  def test_filters_lowercase_token_scheme_from_log
+    log_it(status: 500, request_headers: { 'Authorization' => 'token ghs_secrettoken123' }) do |loog|
+      str = loog.to_s
+      assert_match(/Authorization: "token \[FILTERED\]"/, str)
+      refute_match(/ghs_secrettoken123/, str, 'token-scheme credential must never appear in the log')
     end
   end
 
@@ -64,13 +81,14 @@ class LoggingFormatterTest < Fbe::Test
       refute_empty(str)
       [
         %r{http://example.com},
-        /Authorization:/,
+        /Authorization: "Bearer \[FILTERED\]"/,
         /some request body/,
         %r{HTTP/1.1 502},
         /x-github-api-version-selected: "2022-11-28"/,
         %r{content-type: "text/html; charset=utf-8"},
         "#{body.slice(0, 97)}..."
       ].each { |ptn| assert_match(ptn, str) }
+      refute_match(/github_pat_11AAsecret/, str, 'live token must never appear in the log')
     end
   end
 
@@ -80,7 +98,8 @@ class LoggingFormatterTest < Fbe::Test
     status:,
     method: :get,
     response_body: '{"message": "hello, world!"}',
-    response_headers: { 'content-type' => 'application/json', 'x-github-api-version-selected' => '2022-11-28' }
+    response_headers: { 'content-type' => 'application/json', 'x-github-api-version-selected' => '2022-11-28' },
+    request_headers: { 'Authorization' => 'Bearer github_pat_11AAsecret' }
   )
     loog = Loog::Buffer.new
     formatter = Fbe::Middleware::Formatter.new(logger: loog, options: {})
@@ -90,9 +109,7 @@ class LoggingFormatterTest < Fbe::Test
           method:,
           request_body: 'some request body',
           url: URI('http://example.com'),
-          request_headers: {
-            'Authorization' => 'Bearer github_pat_11AAsecret'
-          }
+          request_headers:
         }
       )
     )


### PR DESCRIPTION
@yegor256 this PR fixes #439.

## What was wrong

`Fbe::Middleware::Formatter` writes the full request `Authorization` header (with the live `Bearer <token>` value) into the logger on any 4xx/5xx response. The class docstring advertises `Authorization: "Bearer [FILTERED]"`, but no `Faraday::Logging::Formatter#filter` was ever registered, so `apply_filters` was a pass-through.

Reproduction (no fbe stubs, just the formatter):

```ruby
require "faraday"
require "loog"
require "fbe/middleware/formatter"

loog = Loog::Buffer.new
fmt = Fbe::Middleware::Formatter.new(logger: loog, options: {})
fmt.request(Faraday::Env.from(
  method: :get, request_body: "x", url: URI("http://example.com"),
  request_headers: { "Authorization" => "Bearer github_pat_REAL_TOKEN" }
))
fmt.response(Faraday::Env.from(
  status: 500, response_body: "err",
  response_headers: { "content-type" => "text/html" }
))
puts loog.to_s
```

Before: `Authorization: "Bearer github_pat_REAL_TOKEN"` in the log.
After: `Authorization: "Bearer [FILTERED]"`.

## Fix

`Fbe::Middleware::Formatter#initialize` now calls `super` and registers a Faraday filter that masks the credential portion of any `Authorization` header while preserving the auth scheme. Works for `Bearer`, `Basic`, lowercase `token`, and JWT-like values.

```ruby
filter(/(Authorization:\s*"?\s*\S+\s+)[^"\s]+/i, '\1[FILTERED]')
```

## Test changes

The previous tests asserted `assert_match(/Authorization:/, str)`, which matches both the leaked and the masked form, so the suite did not detect the leak. The PR replaces those with stricter pairs:

```ruby
assert_match(/Authorization: "Bearer \[FILTERED\]"/, str)
refute_match(/github_pat_11AAsecret/, str, 'live token must never appear in the log')
```

Two new tests cover non-Bearer schemes:
* `test_filters_basic_auth_credentials_from_log` (HTTP Basic with `==` padding)
* `test_filters_lowercase_token_scheme_from_log` (`token ghs_...`)

The `log_it` helper now accepts a `request_headers:` argument so different schemes can be exercised.

## Why this matters even in GitHub Actions

GitHub Actions auto-masks anything from `${{ secrets.X }}`, but the leak is real for everyone else: local development, self-hosted runners, non-Actions CI (GitLab, Buildkite, Jenkins), and any caller piping `loog` to a log shipper that records the plaintext before UI-side masking can kick in. The judges-action `::add-mask::` (#1344 there) is an Actions-side mitigation that misses if the registered token ever differs from what is finally sent.

## Verification

* `bundle exec rake test`: 254 tests, 0 failures
* `bundle exec rubocop`: 0 offenses
* `bundle exec rake` (full default: clean + test + rubocop + picks + yard): exit 0