### PR TITLE
Fix #445: guard log line in roll against unset what/details

### DIFF
--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -208,7 +208,12 @@ class Fbe::Conclude
       )
       @fb.txn do |fbt|
         n = yield(fbt, a)
-        @loog.info("#{n.what}: #{n.details}") unless n.nil?
+        unless n.nil?
+          props = n.all_properties
+          if props.include?('what') && props.include?('details')
+            @loog.info("#{n.what}: #{n.details}")
+          end
+        end
       end
       passed += 1
     end

--- a/test/fbe/test_conclude.rb
+++ b/test/fbe/test_conclude.rb
@@ -163,6 +163,24 @@ class TestConclude < Fbe::Test
     assert_equal(1, fb.size)
   end
 
+  def test_draw_block_returning_non_string_does_not_crash
+    $fb = Factbase.new
+    $global = {}
+    $epoch = Time.now
+    $loog = Loog::NULL
+    $options = Judges::Options.new
+    $fb.insert.foo = 1
+    Fbe.conclude(judge: 'judge-non-string') do
+      quota_unaware
+      on('(exists foo)')
+      draw do |n, _prev|
+        n.score = 42
+      end
+    end
+    f = $fb.query('(exists score)').each.to_a[0]
+    assert_equal(42, f.score)
+  end
+
   def test_catch_fbe_off_quota_exception_correctly
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
@yegor256 — this PR fixes #445 (`Fbe::Conclude#roll` crashing with `RuntimeError: Can't find 'what' attribute` when the `draw` block returns a non-`String`).

## What changes

Per your direction in the issue ("the second option is better: roll should guard the log line against unset attributes"), the `@loog.info("#{n.what}: #{n.details}")` line in `roll` (`lib/fbe/conclude.rb`) now first checks `n.all_properties` and only emits the log line when both `what` and `details` are present on the new fact. The behaviour of `fill` is unchanged — it still only sets `what`/`details` when the block returns a `String` — so existing well-behaved judges keep their info-level log entries.

## Why this approach

`Factbase::Fact` raises `RuntimeError` (not `NoMethodError`) when reading an unset property, so a generic `rescue` would be too broad. Using the public `all_properties` accessor (already used elsewhere in the codebase, e.g. `lib/fbe/delete.rb:32`) makes the guard explicit and side-effect-free.

## Reproduction

The new test `test_draw_block_returning_non_string_does_not_crash` mirrors the minimal repro from the issue — a `draw` block that only assigns `n.score = 42`. Without the fix this raises `RuntimeError: Can't find 'what' attribute out of [_id, _time, _version, score]`. With the fix the new fact is inserted cleanly.

## Verification

- `bundle exec rake test` — 255 tests, 0 failures.
- `bundle exec rake rubocop` — clean.
- `bundle exec rake yard` — clean.
- All 10 CI checks green on this PR.

Closes #445.