### PR TITLE
Fix #446: preserve repo and item context when block raises in Fbe::Iterate#over

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -312,7 +312,13 @@ class Fbe::Iterate
             @since
           else
             @loog.debug("Next is ##{nxt}, starting from it")
-            yield(repo, nxt)
+            begin
+              yield(repo, nxt)
+            rescue Fbe::OffQuota
+              raise
+            rescue StandardError => e
+              raise(e.class, "Failure in repository ##{repo} at ##{nxt}: #{e.message}")
+            end
           end
         unless before[repo].is_a?(Integer)
           raise(Fbe::Error, "Iterator must return an Integer, but #{before[repo].class} was returned")

--- a/test/fbe/test_iterate.rb
+++ b/test/fbe/test_iterate.rb
@@ -483,4 +483,41 @@ class TestIterate < Fbe::Test # rubocop:disable Metrics/ClassLength
     end
     assert_equal(0, count)
   end
+
+  def test_preserves_repo_and_item_context_when_block_raises
+    opts = Judges::Options.new(['repositories=foo/bar', 'testing=true'])
+    fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
+    fb.insert.foo = 42
+    ex =
+      assert_raises(StandardError) do
+        Fbe.iterate(fb:, loog: Loog::NULL, options: opts, global: {}, epoch: Time.now, kickoff: Time.now) do
+          as('context_test')
+          by('(agg (always) (max foo))')
+          repeats(1)
+          over do |_repository, _foo|
+            raise(StandardError, 'boom')
+          end
+        end
+      end
+    assert_includes(ex.message, '42', "Expected message to contain item id, got: #{ex.message.inspect}")
+    assert_match(/repo/i, ex.message, "Expected message to mention repo, got: #{ex.message.inspect}")
+    assert_includes(ex.message, 'boom', "Expected original message preserved, got: #{ex.message.inspect}")
+  end
+
+  def test_does_not_swallow_off_quota_when_block_raises
+    opts = Judges::Options.new(['repositories=foo/bar', 'testing=true'])
+    fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
+    fb.insert.foo = 42
+    cycles = 0
+    Fbe.iterate(fb:, loog: Loog::NULL, options: opts, global: {}, epoch: Time.now, kickoff: Time.now) do
+      as('quota_in_block_test')
+      by('(agg (always) (max foo))')
+      repeats(5)
+      over do |_repository, _foo|
+        cycles += 1
+        raise(Fbe::OffQuota, 'no more quota')
+      end
+    end
+    assert_equal(1, cycles)
+  end
 end


### PR DESCRIPTION
@yegor256 — closes #446.

In `Fbe::Iterate#over` (`lib/fbe/iterate.rb:315`), `yield(repo, nxt)` was called with no `begin/rescue`. The only `rescue` on the method is `rescue Fbe::OffQuota => e` at the bottom — every other `StandardError` raised by the user-supplied block propagated up without a hint of which repository or item was being processed at the moment of the failure, making production crashes hard to triage.

## Change

Wrap the `yield` so that:

* `Fbe::OffQuota` is re-raised unchanged so the existing handler at the bottom of `over` (the one that turns it into `@loog.info(e.message)`) keeps working;
* any other `StandardError` is re-raised with the **same class** but a contextual message of the form `"Failure in repository #<repo> at #<nxt>: <original message>"`. The original exception is preserved as `cause` (Ruby sets it automatically when `raise` is called inside a rescue), so the original backtrace is not lost.

```ruby
@loog.debug("Next is ##{nxt}, starting from it")
begin
  yield(repo, nxt)
rescue Fbe::OffQuota
  raise
rescue StandardError => e
  raise(e.class, "Failure in repository ##{repo} at ##{nxt}: #{e.message}")
end
```

I went with a same-class re-raise rather than the `raise "msg"` pattern from the bug report so callers that `rescue` a specific class (e.g. `Fbe::Error`, `ArgumentError`) still match.

## Tests

* `test_preserves_repo_and_item_context_when_block_raises` — fails on `master`, asserts the new contextual message contains the item id, the word "repo", and the original message text.
* `test_does_not_swallow_off_quota_when_block_raises` — guards the path where the block itself raises `Fbe::OffQuota`, verifying it still flows into the existing handler (cycles == 1, i.e. the iteration stopped).

## CI

All 10 checks green (`rake` on ubuntu + macOS, rubocop/markdown-lint/pdd/reuse/typos/actionlint/copyrights/yamllint/xcop).