### PR TITLE
#457: use judge parameter instead of $judge global in log messages

### DIFF
--- a/lib/fbe/regularly.rb
+++ b/lib/fbe/regularly.rb
@@ -44,12 +44,12 @@ def Fbe.regularly(area, p_every_days, p_since_days = nil, fb: Fbe.fb, judge: $ju
   ).each.first
   if recent
     loog.info(
-      "#{$judge} statistics were collected #{recent.when.ago} ago, " \
+      "#{judge} statistics were collected #{recent.when.ago} ago, " \
       "skipping now (we run it every #{interval} days)"
     )
     return
   end
-  loog.info("#{$judge} statistics weren't collected for the last #{interval} days")
+  loog.info("#{judge} statistics weren't collected for the last #{interval} days")
   fb.txn do |fbt|
     f = fbt.insert
     f.what = judge

--- a/test/fbe/test_regularly.rb
+++ b/test/fbe/test_regularly.rb
@@ -35,6 +35,22 @@ class TestRegularly < Fbe::Test
     assert_equal(0, fb.size)
   end
 
+  def test_log_uses_judge_parameter_not_global
+    $judge = 'global_judge'
+    fb = Factbase.new
+    loog = Loog::Buffer.new
+    judge = 'custom_judge'
+    Fbe.regularly('pmp', 'interval', 'days', fb:, loog:, judge:) do |f|
+      f.foo = 42
+    end
+    Fbe.regularly('pmp', 'interval', 'days', fb:, loog:, judge:) do |f|
+      f.foo = 42
+    end
+    output = loog.to_s
+    assert_includes(output, 'custom_judge')
+    refute_includes(output, 'global_judge')
+  end
+
   def test_uses_default_since_days_when_pmp_lacks_property
     fb = Factbase.new
     fb.txn do |fbt|


### PR DESCRIPTION
Fixes #457.

Replaced `$judge` global with the `judge` keyword parameter in two `loog.info` calls inside `Fbe.regularly`. The fact insertion already used the parameter correctly (`f.what = judge`); only the log messages were inconsistent. With this fix, callers that pass an explicit `judge:` argument (tests, multi-judge setups) get correct judge names in the log output.

Added regression test `test_log_uses_judge_parameter_not_global` that sets `$judge` to one value, calls `Fbe.regularly` with a different `judge:`, captures output via `Loog::Buffer`, and asserts the parameter value (not the global) appears in the logs.
