### PR TITLE
fix: use judge parameter in repeatedly log

### DIFF
--- a/lib/fbe/repeatedly.rb
+++ b/lib/fbe/repeatedly.rb
@@ -45,7 +45,7 @@ def Fbe.repeatedly(area, p_every_hours, fb: Fbe.fb, judge: $judge, loog: $loog, 
       (gt when (minus (to_time (env 'TODAY' '#{Time.now.utc.iso8601}')) '#{hours} hours')))"
   ).each.first
   if recent
-    loog.info("#{$judge} was executed #{recent.when.ago} ago, skipping now (we run it every #{hours} hours)")
+    loog.info("#{judge} was executed #{recent.when.ago} ago, skipping now (we run it every #{hours} hours)")
     return
   end
   f = fb.query("(and (eq what '#{judge}'))").each.first

--- a/test/fbe/test_repeatedly.rb
+++ b/test/fbe/test_repeatedly.rb
@@ -28,4 +28,24 @@ class TestRepeatedly < Fbe::Test
     assert_equal(1, $fb.size)
     assert_equal(42, $fb.query('(always)').each.first.foo)
   end
+
+  def test_log_uses_judge_parameter_not_global
+    $judge = 'global_judge'
+    fb = Factbase.new
+    $fb = fb
+    $global = {}
+    $options = Judges::Options.new
+    loog = Loog::Buffer.new
+    $loog = loog
+    judge = 'custom_judge'
+    Fbe.repeatedly('pmp', 'every_x_hours', fb:, loog:, judge:) do |f|
+      f.foo = 42
+    end
+    Fbe.repeatedly('pmp', 'every_x_hours', fb:, loog:, judge:) do |f|
+      f.foo = 42
+    end
+    output = loog.to_s
+    assert_includes(output, 'custom_judge')
+    refute_includes(output, 'global_judge')
+  end
 end


### PR DESCRIPTION
## Summary
- use the `judge:` parameter in the `Fbe.repeatedly` skip log instead of the `$judge` global
- add regression coverage for the parameter/global mismatch

Closes #464.

## Validation
- `bundle exec ruby test/fbe/test_repeatedly.rb` (2 tests, 6 assertions, 0 failures)
- `bundle exec rake test` (274 tests, 774 assertions, 0 failures, 9 skips)
- `bundle exec rake rubocop` (65 files inspected, no offenses)
- `bundle exec rake yard` (completed, 81.82% documented)
- `bundle exec rake picks` (exited 0)
- `git diff --check HEAD~1 HEAD` (passed)
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` (no leaks found)

## Notes
- Local validation used Homebrew portable Ruby 4.0.3 because the system Ruby is 2.6.10.
- The test runs emit Ruby 4/Bundler constant redefinition warnings and existing `award.rb` future frozen string warnings, but the commands above exited 0.
