### PR TITLE
feat(query): ignore system attributes _id/_time/_version when matching

### DIFF
--- a/lib/fbe/if_absent.rb
+++ b/lib/fbe/if_absent.rb
@@ -62,7 +62,7 @@ def Fbe.if_absent(fb: Fbe.fb, always: false)
       end
     end
   yield(f)
-  q = attrs.except('_id', '_time', '_version').map do |k, v|
+  q = attrs.except(:_id, :_time, :_version).map do |k, v|
     vv = v.to_s
     if v.is_a?(String)
       vv = "'#{vv.gsub('"', '\\\\"').gsub("'", "\\\\'")}'"

--- a/lib/fbe/just_one.rb
+++ b/lib/fbe/just_one.rb
@@ -44,7 +44,7 @@ def Fbe.just_one(fb: Fbe.fb)
       end
     end
   yield(f)
-  q = attrs.except('_id', '_time', '_version').map do |k, v|
+  q = attrs.except(:_id, :_time, :_version).map do |k, v|
     vv = v.to_s
     if v.is_a?(String)
       vv = "'#{vv.gsub('"', '\\\\"').gsub("'", "\\\\'")}'"

--- a/test/fbe/test_if_absent.rb
+++ b/test/fbe/test_if_absent.rb
@@ -87,6 +87,17 @@ class TestIfAbsent < Fbe::Test
     assert_nil(n)
   end
 
+  def test_ignores_system_attributes_when_matching
+    fb = Factbase.new
+    fb.insert.foo = 'hello dude'
+    n =
+      Fbe.if_absent(fb:) do |f|
+        f._id = 42
+        f.foo = 'hello dude'
+      end
+    assert_nil(n)
+  end
+
   def test_complex_injects
     fb = Factbase.new
     fact = fb.insert

--- a/test/fbe/test_just_one.rb
+++ b/test/fbe/test_just_one.rb
@@ -30,4 +30,15 @@ class TestJustOne < Fbe::Test
       end
     assert_equal(42, n.foo)
   end
+
+  def test_ignores_system_attributes_when_matching
+    fb = Factbase.new
+    fb.insert.foo = 'hello dude'
+    n =
+      Fbe.just_one(fb:) do |f|
+        f._id = 42
+        f.foo = 'hello dude'
+      end
+    refute_nil(n)
+  end
 end


### PR DESCRIPTION
Closes #460. The `except` call in `if_absent` and `just_one` used string keys while `attrs` is keyed by symbols, so the system attributes were never stripped from the match query. This passes symbols to `except` and adds regression tests for both helpers.