### PR TITLE
#451 guard Fbe::Middleware::RateLimit state with a mutex

### DIFF
--- a/lib/fbe/middleware/rate_limit.rb
+++ b/lib/fbe/middleware/rate_limit.rb
@@ -24,8 +24,6 @@ require_relative '../../fbe/middleware'
 # Copyright:: Copyright (c) 2024-2026 Zerocracy
 # License:: MIT
 class Fbe::Middleware::RateLimit < Faraday::Middleware
-  # NOT thread-safe: assumes single-threaded use (judges run sequentially in judges-action).
-  #
   # Initializes the rate limit middleware.
   #
   # @param [Object] app The next middleware in the stack
@@ -35,6 +33,7 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
     @remaining = 0
     @searchleft = 0
     @counter = 0
+    @lock = Mutex.new
   end
 
   # Processes the HTTP request and handles rate limit caching.
@@ -43,9 +42,9 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
   # @return [Faraday::Response] The response from cache or the next middleware
   def call(env)
     if env.url.path == '/rate_limit'
-      handle_rate_limit_request(env)
+      @lock.synchronize { handle_rate_limit_request(env) }
     else
-      track_request(env.url.path)
+      @lock.synchronize { track_request(env.url.path) }
       @app.call(env)
     end
   end

--- a/test/fbe/middleware/test_rate_limit.rb
+++ b/test/fbe/middleware/test_rate_limit.rb
@@ -236,6 +236,47 @@ class RateLimitTest < Fbe::Test
     assert_equal(4999, parsed['rate']['remaining'])
   end
 
+  def test_concurrent_non_rate_limit_requests_do_not_lose_decrements
+    payload = {
+      'rate' => { 'limit' => 5000, 'remaining' => 10_000, 'reset' => 1_672_531_200 },
+      'resources' => {
+        'core' => { 'limit' => 5000, 'remaining' => 10_000, 'reset' => 1_672_531_200 },
+        'search' => { 'limit' => 30, 'remaining' => 1_000, 'reset' => 1_672_531_200 }
+      }
+    }
+    stub_request(:get, 'https://api.github.com/rate_limit')
+      .to_return(status: 200, body: payload.to_json, headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://api.github.com/user')
+      .to_return(status: 200, body: '{"login":"x"}', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://api.github.com/search/issues?q=z')
+      .to_return(status: 200, body: '{"items":[]}', headers: { 'Content-Type' => 'application/json' })
+    conn = create_connection
+    conn.get('/rate_limit')
+    threads =
+      Array.new(10) do
+        Thread.new do
+          4.times do
+            conn.get('/user')
+            conn.get('/search/issues?q=z')
+          end
+        end
+      end
+    threads.each(&:join)
+    response = conn.get('/rate_limit')
+    assert_equal(10_000 - 40, response.body['rate']['remaining'])
+    assert_equal(1_000 - 40, response.body['resources']['search']['remaining'])
+  end
+
+  def test_concurrent_rate_limit_requests_refresh_once
+    payload = { 'rate' => { 'limit' => 5000, 'remaining' => 4999, 'reset' => 1_672_531_200 } }
+    stub_request(:get, 'https://api.github.com/rate_limit')
+      .to_return(status: 200, body: payload.to_json, headers: { 'Content-Type' => 'application/json' })
+    conn = create_connection
+    threads = Array.new(20) { Thread.new { conn.get('/rate_limit') } }
+    threads.each(&:join)
+    assert_requested(:get, 'https://api.github.com/rate_limit', times: 1)
+  end
+
   def test_cached_body_is_not_leaked_to_callers
     payload = {
       'rate' => { 'limit' => 5000, 'remaining' => 4999, 'reset' => 1_672_531_200 },


### PR DESCRIPTION
Closes #451.

`Fbe::Middleware::RateLimit` keeps mutable state (`@cached`, `@remaining`, `@searchleft`, `@counter`) in plain instance variables and updates them with non-atomic compound operations like `@counter += 1` and `@remaining -= 1`. The middleware instance is shared across every request through the same Faraday connection, so any concurrent caller (parallel judges, fiber-based fetches, anything that uses `Fbe.octo` from threads) would race on these vars and lose decrements, serve stale cached `/rate_limit` for longer than the 100-request window intended, and let two threads through the cache-miss branch at the same time.

The change adds a `Mutex` around the cache-refresh path in `handle_rate_limit_request` and around the counter mutation in `track_request`, while keeping `@app.call(env)` outside the lock so a slow downstream request does not serialize unrelated callers. The "NOT thread-safe" header comment that documented the prior limitation is gone.

Local validation against ruby 3.3.6 on linux:
- `bundle exec rake test TEST=test/fbe/middleware/test_rate_limit.rb` — 16 tests, 32 assertions, 0 failures, 0 errors, including the two new regression tests `test_concurrent_non_rate_limit_requests_do_not_lose_decrements` and `test_concurrent_rate_limit_requests_refresh_once`.
- `bundle exec rake test` — 275 tests, 760 assertions, 0 new failures (10 pre-existing errors in `test_octo.rb` and adjacent quota-dependent tests reproduce on `master` in this environment and are unrelated to this change).
- `bundle exec rake rubocop` — 65 files inspected, no offenses.
- `bundle exec rake yard` — 81.82% documented, no new warnings.
