### PR TITLE
#449 route Fbe.octo's send and public_send through the quota guard

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -242,6 +242,14 @@ def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable 
             raise(Fbe::OffQuota, "We are off-quota (remaining: #{o.rate_limit.remaining}), can't do #{m}()")
           end
         end
+      o.instance_eval do
+        def send(...)
+          __send__(...)
+        end
+        def public_send(...) # rubocop:disable Layout/EmptyLineBetweenDefs, Elegant/GoodMethodName
+          __send__(...)
+        end
+      end
       o
     end
 end

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -288,6 +288,48 @@ class TestOcto < Fbe::Test # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def test_send_routes_through_quota_guard
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 4_999 }, resources: { core: { remaining: 4_999 }, search: { remaining: 1 } } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '4999' }
+    )
+    Fbe::SEARCH_METHODS.each do |m|
+      o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new)
+      assert_raises(Fbe::OffQuota, "send(:#{m}) must be blocked when search quota is exhausted") do
+        o.send(m, 'q') # rubocop:disable Style/Send
+      end
+    end
+  end
+
+  def test_public_send_routes_through_quota_guard
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 4_999 }, resources: { core: { remaining: 4_999 }, search: { remaining: 1 } } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '4999' }
+    )
+    Fbe::SEARCH_METHODS.each do |m|
+      o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new)
+      assert_raises(Fbe::OffQuota, "public_send(:#{m}) must be blocked when search quota is exhausted") do
+        o.public_send(m, 'q')
+      end
+    end
+  end
+
+  def test_send_routes_core_methods_through_quota_guard
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new)
+    assert_raises(Fbe::OffQuota, 'send(:user) must be blocked when core quota is exhausted') do
+      o.send(:user, 42) # rubocop:disable Style/Send
+    end
+    assert_raises(Fbe::OffQuota, 'public_send(:user) must be blocked when core quota is exhausted') do
+      o.public_send(:user, 42) # rubocop:disable Style/SendWithLiteralMethodName
+    end
+  end
+
   def test_print_quota_left_while_initialize
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
Closes #449.

`Fbe.octo` wraps Octokit with the `intercepted` gem, which builds a `BasicObject` subclass and routes every call through `method_missing`. Neither `send` nor `public_send` is defined on `BasicObject`, so `o.send(:search_issues, 'q')` arrived at the interceptor block with `m=:send`, fell through the `Fbe::SEARCH_METHODS` and `off_quota?` guard list, and dispatched the underlying `search_issues` directly — the search-quota check from #447 never ran. `public_send` had the same problem. The repro from #449 (`o.send(:search_issues, 'q')` while search is exhausted) reached the GitHub API instead of raising `Fbe::OffQuota`.

Define `send` and `public_send` on the intercepted wrapper that forward to `__send__`. Both forwarders use Ruby's `...` shorthand to preserve positional, keyword, and block arguments. `__send__` on the wrapper hits the dispatcher that already triggers the interceptor block, so the real method name now reaches the guard and the existing quota logic raises as designed for both the core and search resources.

Local validation against ruby 3.3.6 on linux:
- `bundle exec ruby -Ilib -Itest test/fbe/test_octo.rb -n "/(quota|send_routes|public_send)/"` — 18 tests, 46 assertions, 0 failures, 1 pre-existing error (`test_pauses_when_quota_is_exceeded`, reproduces on `master` in this environment and is unrelated to this change).
- `bundle exec ruby -Ilib -Itest test/fbe/test_octo.rb` — 63 tests, 167 assertions, 0 failures, 10 pre-existing errors, 2 skips (every error reproduces on `master` in this environment).
- `bundle exec rubocop lib/fbe/octo.rb test/fbe/test_octo.rb` — 2 files inspected, no offenses.

The three new tests pin both entry points (`send`, `public_send`) against both quota resources: every search method blocks under an exhausted search resource, and `user(42)` blocks under an exhausted core resource when invoked through either forwarder.
