### PR TITLE
#434 raise on GraphQL errors in Fbe::Graph#query instead of returning null data

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -45,6 +45,9 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
   #   puts result.viewer.login #=> "octocat"
   def query(qry)
     result = client.query(client.parse(qry))
+    unless result.errors.empty?
+      raise(Fbe::Error, "GitHub GraphQL query failed: #{result.errors.messages.values.flatten.join('; ')}")
+    end
     result.data
   end
 

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -20,6 +20,23 @@ class TestGitHubGraph < Fbe::Test
     Fbe.github_graph(options:, loog: Loog::NULL, global:)
   end
 
+  def test_raises_when_graphql_response_carries_errors
+    WebMock.disable_net_connect!
+    graph = Fbe::Graph.new(token: 'x')
+    errors = Object.new
+    errors.define_singleton_method(:empty?) { false }
+    errors.define_singleton_method(:messages) { { 'data' => ['Could not resolve to a Repository with the name'] } }
+    response = Object.new
+    response.define_singleton_method(:errors) { errors }
+    response.define_singleton_method(:data) { nil }
+    fake_client = Object.new
+    fake_client.define_singleton_method(:parse) { |q| q }
+    fake_client.define_singleton_method(:query) { |_parsed| response }
+    graph.define_singleton_method(:client) { fake_client }
+    e = assert_raises(Fbe::Error) { graph.query('{ viewer { login } }') }
+    assert_match(/Could not resolve to a Repository/, e.message)
+  end
+
   def test_simple_use_graph
     skip("it's a live test, run it manually if you need it")
     WebMock.allow_net_connect!


### PR DESCRIPTION
Closes #434.

`Fbe::Graph#query` in `lib/fbe/github_graph.rb` previously returned `result.data` unconditionally and threw away `result.errors`. Downstream methods in the same file then chose between two contradictory recoveries for the missing-repository case: `pull_requests_with_reviews` raised on the resulting null repository, while `total_issues_and_pulls`, `total_commits_pushed`, `total_releases_published`, and `resolved_conversations` silently coerced the null to zero or to an empty array. #434 (Option 3, confirmed in-thread by the maintainer) asks for the root-cause fix: raise once at `query`, so callers can drop their per-method nil guards in follow-ups.

The change is a three-line guard that raises `Fbe::Error` carrying the joined GraphQL error messages when `result.errors` is non-empty; behaviour on success is unchanged. The pre-existing per-method nil checks stay in place for this pass to keep the diff focused — they become redundant once this guard is in and can be removed in separate pull requests, one method at a time, as #434 anticipated.

`bundle exec rake test` runs the suite locally with `274 tests, 760 assertions, 0 failures, 10 errors, 9 skips`; the new `test_raises_when_graphql_response_carries_errors` is among the 274 and passes, and the ten remaining errors are the same pre-existing `Fbe::OffQuota` failures present on `master` (touching `octo`, `sqlite_store`, and `rate_limit` middleware, not `github_graph`). `bundle exec rubocop` reports `65 files inspected, no offenses detected`.