### PR TITLE
#468 guard 403 content-type read in formatter with safe navigation

### DIFF
--- a/lib/fbe/middleware/formatter.rb
+++ b/lib/fbe/middleware/formatter.rb
@@ -68,7 +68,7 @@ class Fbe::Middleware::Formatter < Faraday::Logging::Formatter
   # @note Special handling for 403 JSON responses to show compact error message
   def response(http) # rubocop:disable Metrics/AbcSize
     return if http.status < 400
-    if http.status == 403 && http.response_headers['content-type'].start_with?('application/json')
+    if http.status == 403 && http.response_headers['content-type']&.start_with?('application/json')
       warn(
         [
           "#{@req.method.upcase} #{apply_filters(@req.url.to_s)}",

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -51,6 +51,15 @@ class LoggingFormatterTest < Fbe::Test
     end
   end
 
+  def test_limit_response_without_content_type_header
+    log_it(status: 403, response_body: '', response_headers: {}) do |loog|
+      str = loog.to_s
+      refute_empty(str)
+      assert_match(%r{http://example.com}, str)
+      assert_match(%r{HTTP/1.1 403}, str)
+    end
+  end
+
   def test_filters_basic_auth_credentials_from_log
     log_it(status: 500, request_headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' }) do |loog|
       str = loog.to_s


### PR DESCRIPTION
Closes #468.

The 403 branch of `Fbe::Middleware::Formatter#response` in `lib/fbe/middleware/formatter.rb:71` reads `http.response_headers['content-type'].start_with?('application/json')` without guarding against a missing header. When GitHub returns a 403 with no `Content-Type` (which it emits for some abuse-rate-limit and secondary-rate-limit responses), the header is `nil` and `nil.start_with?` raises `NoMethodError`, crashing the Faraday logger middleware before the request can be handled. The 500 branch two lines below already uses `&.start_with?('text')`; this PR brings the 403 branch into line.

The fix is a one-character change: switch `['content-type'].start_with?` to `['content-type']&.start_with?`. Behaviour on 403 responses that do carry an `application/json` Content-Type is unchanged — the compact warning still fires. 403 responses without a `Content-Type` now fall through to the general error-formatting block on lines 98-108, so the full request/response dump (URL, headers, status, body) reaches the log instead of crashing the middleware.

`bundle exec ruby -Ilib -Itest test/fbe/middleware/test_formatter.rb` — 8 tests, 54 assertions, 0 failures, 0 errors; the new `test_limit_response_without_content_type_header` drives `log_it` through a 403 response with an empty `response_headers` hash and asserts the log contains the request URL and the `HTTP/1.1 403` status line. `rubocop lib/fbe/middleware/formatter.rb test/fbe/middleware/test_formatter.rb` — 2 files inspected, no offenses.