### PR TITLE
#469 keep hash form on existing fact when adding absent properties

### DIFF
--- a/lib/fbe/overwrite.rb
+++ b/lib/fbe/overwrite.rb
@@ -40,14 +40,23 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
       before[k.to_s] = fact[k]
     end
     modified = false
+    adding = true
     property_or_hash.each do |k, vv|
       raise(Fbe::Error, "The value for #{k} is nil") if vv.nil?
       vv = [vv] unless vv.is_a?(Array)
       next if before[k.to_s] == vv
+      adding = false unless before[k.to_s].nil?
       before[k.to_s] = vv
       modified = true
     end
     return fact unless modified
+    if adding
+      property_or_hash.each do |k, vv|
+        vv = [vv] unless vv.is_a?(Array)
+        vv.each { |v| fact.public_send(:"#{k}=", v) }
+      end
+      return
+    end
     id = fact[fid]&.first
     raise(Fbe::Error, "There is no #{fid} in the fact, cannot use Fbe.overwrite") if id.nil?
     raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?

--- a/test/fbe/test_overwrite.rb
+++ b/test/fbe/test_overwrite.rb
@@ -185,6 +185,23 @@ class TestOverwrite < Fbe::Test # rubocop:disable Metrics/ClassLength
     assert_equal(0, f.pos)
   end
 
+  def test_hash_form_preserves_id_when_only_adding_absent_properties
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    f = fbx.insert
+    f.foo = 42
+    fbx.insert
+    before = f._id
+    Fbe.overwrite(f, { bar: 44, baz: 'new' }, fb: fbx)
+    result = fbx.query('(eq bar 44)').each.first
+    assert_equal(before, result._id)
+    assert_equal(42, result['foo'].first)
+    assert_equal('new', result['baz'].first)
+  end
+
   def test_overwrite_with_hash_preserves_other_properties
     fb = Factbase.new
     f = fb.insert


### PR DESCRIPTION
The hash form of `Fbe.overwrite` destroys and re-inserts the fact whenever any key in the input hash is not already present, even when the call is a pure add. The scalar form has the opposite behaviour on the same case: `lib/fbe/overwrite.rb:70-75` assigns the value on the existing fact and returns without touching the factbase. Issue #469 spells out the divergence: a re-inserted fact picks up new `_id`, `_time`, and `_version` from the `Factbase::Pre` block in `lib/fbe/fb.rb:43-49`, so the fact's identity changes silently on a path the docstring says only "adds" the property.

The fix mirrors the scalar form's add-in-place branch inside the hash form. As `property_or_hash` is walked, a flag tracks whether every key whose value actually changes was absent on the fact; when the flag survives the loop, the hash form assigns each value directly on the existing fact and returns, bypassing the `delete!` / `txn` / `insert` cycle. A call that touches even one already-present property still falls through to the destroy-recreate path, so existing behaviour for replacements is unchanged.

Local validation against ruby 3.3.6 on linux:
- `bundle exec ruby -Ilib -Itest test/fbe/test_overwrite.rb` — 28 tests, 59 assertions, 0 failures, 0 errors, 0 skips (one new test pins the invariant).
- `bundle exec rubocop lib/fbe/overwrite.rb test/fbe/test_overwrite.rb` — 2 files inspected, no offenses.

The new test, `test_hash_form_preserves_id_when_only_adding_absent_properties`, walks the scalar form's existing `test_without_previous_property` invariant through the hash form: the same fact is observed before and after the call, the new properties are present, and `_id` is unchanged.

Closes #469.