### PR TITLE
#474: anchor repository mask regex

### DIFF
--- a/lib/fbe/unmask_repos.rb
+++ b/lib/fbe/unmask_repos.rb
@@ -12,11 +12,11 @@ require_relative 'over'
 #
 # @example Basic wildcard matching
 #   Fbe.mask_to_regex('zerocracy/*')
-#   # => /zerocracy\/.*/i
+#   # => /\Azerocracy\/.*\z/i
 #
 # @example Specific repository (no wildcard)
 #   Fbe.mask_to_regex('zerocracy/fbe')
-#   # => /zerocracy\/fbe/i
+#   # => /\Azerocracy\/fbe\z/i
 #
 # @param [String] mask Repository mask in format 'org/repo' where repo can contain '*'
 # @return [Regexp] Case-insensitive regular expression for matching repositories
@@ -24,7 +24,7 @@ require_relative 'over'
 def Fbe.mask_to_regex(mask)
   org, repo = mask.split('/')
   raise(Fbe::Error, "Org '#{org}' can't have an asterisk") if org.include?('*')
-  Regexp.compile("#{org}/#{repo.gsub('*', '.*')}", Regexp::IGNORECASE)
+  Regexp.compile("\\A#{org}/#{repo.gsub('*', '.*')}\\z", Regexp::IGNORECASE)
 end
 
 # Resolves repository masks to actual GitHub repository names.

--- a/test/fbe/test_unmask_repos.rb
+++ b/test/fbe/test_unmask_repos.rb
@@ -50,6 +50,19 @@ class TestUnmaskRepos < Fbe::Test
     assert_equal(2, list.size)
   end
 
+  def test_mask_to_regex_matches_the_entire_repository_name
+    re = Fbe.mask_to_regex('zerocracy/judges-action')
+    assert_match(re, 'zerocracy/judges-action')
+    refute_match(re, 'zerocracy/judges-action-old')
+    refute_match(re, 'prefix/zerocracy/judges-action')
+  end
+
+  def test_mask_to_regex_keeps_wildcards
+    re = Fbe.mask_to_regex('zerocracy/judges-*')
+    assert_match(re, 'zerocracy/judges-action')
+    refute_match(re, 'prefix/zerocracy/judges-action')
+  end
+
   def test_live_usage
     skip('Run it only manually, since it touches GitHub API')
     opts = Judges::Options.new({ 'repositories' => 'zerocracy/*,-zerocracy/judges-action,zerocracy/datum' })


### PR DESCRIPTION
Fixes #474.

What changed:
- Anchor `Fbe.mask_to_regex` with `\A` and `\z` so masks must match the complete `org/repo` full name.
- Add regression coverage for an exact mask not matching prefix-collision repositories.
- Keep wildcard masks working for normal repository-name suffixes.

Validation:
- Red before implementation: `bundle exec ruby test\fbe\test_unmask_repos.rb -- --no-cov` failed on the new prefix-collision assertions.
- Green after implementation: `bundle exec ruby test\fbe\test_unmask_repos.rb -- --no-cov` passed: 7 tests, 18 assertions, 0 failures, 0 errors, 1 skipped.
- `bundle exec rubocop lib\fbe\unmask_repos.rb test\fbe\test_unmask_repos.rb` passed with no offenses.
- `ruby -c lib\fbe\unmask_repos.rb` and `ruby -c test\fbe\test_unmask_repos.rb` passed.
- `git diff --check` passed.
- `git diff -- lib\fbe\unmask_repos.rb test\fbe\test_unmask_repos.rb | gitleaks stdin --no-banner --redact` reported no leaks.

Limitation:
- `bundle exec rake test` is locally blocked on this Windows setup before reaching this patch area because `typhoeus/ethon` cannot load `libcurl` while loading unrelated `test_enter.rb`. I did not change that path.