### PR TITLE
#473: omit empty releases cursor

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -490,11 +490,12 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
     total = 0
     cursor = nil
     loop do
+      after = "after: \"#{cursor}\", " unless cursor.nil?
       result = query(
         <<~GRAPHQL
           {
             repository(owner: "#{owner}", name: "#{name}") {
-              releases(first: 25, after: "#{cursor}", orderBy: { field: CREATED_AT, direction: DESC }) {
+              releases(#{after}first: 25, orderBy: { field: CREATED_AT, direction: DESC }) {
                 nodes {
                   isDraft
                   publishedAt

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -315,4 +315,17 @@ class TestGitHubGraph < Fbe::Test
     graph.pull_request_reviews('foo', 'bar', pulls: [[2, nil]])
     refute_includes(captured, 'after: ""')
   end
+
+  def test_total_releases_published_omits_after_when_cursor_is_nil
+    WebMock.disable_net_connect!
+    graph = Fbe::Graph.new(token: 'fake')
+    captured = nil
+    releases = { 'nodes' => [], 'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil } }
+    graph.define_singleton_method(:query) do |qry|
+      captured = qry
+      { 'repository' => { 'releases' => releases } }
+    end
+    graph.total_releases_published('foo', 'bar', Time.parse('2025-12-16T15:00:00Z'))
+    refute_includes(captured, 'after: ""')
+  end
 end


### PR DESCRIPTION
﻿Closes #473.

What changed:
- Applies the same conditional after interpolation used by adjacent GraphQL methods to total_releases_published.
- Adds a regression test that captures the first releases query and verifies it no longer sends after: empty string when the cursor is nil.

Validation:
- Red before the production change: bundle exec ruby test\fbe\test_github_graph.rb -- --no-cov failed on test_total_releases_published_omits_after_when_cursor_is_nil because the query contained after: empty string.
- Green after the production change: bundle exec ruby test\fbe\test_github_graph.rb -- --no-cov passed with 23 tests, 48 assertions, 0 failures, 0 errors, 6 skips.
- bundle exec rubocop lib\fbe\github_graph.rb test\fbe\test_github_graph.rb
- ruby -c lib\fbe\github_graph.rb
- ruby -c test\fbe\test_github_graph.rb
- git diff --check
- git diff -- lib\fbe\github_graph.rb test\fbe\test_github_graph.rb | gitleaks stdin --no-banner --redact

Limitations:
- I also tried bundle exec rake test locally on Windows. It is blocked before the full suite completes by the existing typhoeus/ethon libcurl loading issue while requiring test_enter.rb, so I am not claiming a local full-suite pass.
