### PR TITLE
#480: align codecov Ruby version with rake

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.5
+          ruby-version: 3.3
           bundler-cache: true
       - run: bundle config set --global path "$(pwd)/vendor/bundle"
       - run: bundle install --no-color

--- a/test/test_workflows.rb
+++ b/test/test_workflows.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'minitest/autorun'
+require 'yaml'
+
+class TestWorkflows < Minitest::Test
+  def test_codecov_uses_rake_ruby_version
+    root = File.expand_path('..', __dir__)
+    codecov = YAML.safe_load_file(File.join(root, '.github', 'workflows', 'codecov.yml'))
+    rake = YAML.safe_load_file(File.join(root, '.github', 'workflows', 'rake.yml'))
+    codecov_steps = codecov.fetch('jobs').fetch('codecov').fetch('steps')
+    codecov_step = codecov_steps.find { |step| step['uses'] == 'ruby/setup-ruby@v1' }
+    codecov_ruby = codecov_step.fetch('with').fetch('ruby-version')
+    rake_matrix = rake.fetch('jobs').fetch('rake').fetch('strategy').fetch('matrix')
+    rake_ruby = rake_matrix.fetch('ruby').first
+    assert_equal(rake_ruby, codecov_ruby)
+  end
+end

--- a/test/test_workflows.rb
+++ b/test/test_workflows.rb
@@ -9,13 +9,13 @@ require 'yaml'
 class TestWorkflows < Minitest::Test
   def test_codecov_uses_rake_ruby_version
     root = File.expand_path('..', __dir__)
-    codecov = YAML.safe_load_file(File.join(root, '.github', 'workflows', 'codecov.yml'))
-    rake = YAML.safe_load_file(File.join(root, '.github', 'workflows', 'rake.yml'))
-    codecov_steps = codecov.fetch('jobs').fetch('codecov').fetch('steps')
-    codecov_step = codecov_steps.find { |step| step['uses'] == 'ruby/setup-ruby@v1' }
-    codecov_ruby = codecov_step.fetch('with').fetch('ruby-version')
-    rake_matrix = rake.fetch('jobs').fetch('rake').fetch('strategy').fetch('matrix')
-    rake_ruby = rake_matrix.fetch('ruby').first
-    assert_equal(rake_ruby, codecov_ruby)
+    c = YAML.safe_load_file(File.join(root, '.github', 'workflows', 'codecov.yml'))
+    r = YAML.safe_load_file(File.join(root, '.github', 'workflows', 'rake.yml'))
+    ss = c.fetch('jobs').fetch('codecov').fetch('steps')
+    s = ss.find { |step| step['uses'] == 'ruby/setup-ruby@v1' }
+    cv = s.fetch('with').fetch('ruby-version')
+    m = r.fetch('jobs').fetch('rake').fetch('strategy').fetch('matrix')
+    rv = m.fetch('ruby').first
+    assert_equal(rv, cv)
   end
 end


### PR DESCRIPTION
Fixes #480.

What changed:
- set the Codecov workflow's ruby/setup-ruby version to 3.3, matching the existing rake workflow matrix
- add a small workflow regression test that keeps the Codecov Ruby version aligned with the rake matrix

Validation:
- red: ruby test/test_workflows.rb failed before the workflow change with Expected: 3.3 / Actual: 4.0.5
- green: ruby test/test_workflows.rb
- git diff --check
- gitleaks dir --no-banner --redact --exit-code 1 .

Limitation:
- bundle exec rake test was attempted locally, but this Windows environment is missing locked gems after psych 5.3.1 failed to build because yaml.h is unavailable. The targeted workflow test above runs without Bundler and covers this change directly.