### PR TITLE
#481: preserve true bool PMP defaults

### DIFF
--- a/lib/fbe/pmp.rb
+++ b/lib/fbe/pmp.rb
@@ -92,7 +92,7 @@ def Fbe.pmp(fb: Fbe.fb, global: $global, options: $options, loog: $loog) # ruboc
             case type
             when 'int' then Integer(Float(result).truncate)
             when 'float' then Float(result)
-            when 'bool' then result == 'true'
+            when 'bool' then result.to_s == 'true'
             else result
             end
           pmpv.new(result, default, type, memo)

--- a/test/fbe/test_pmp.rb
+++ b/test/fbe/test_pmp.rb
@@ -37,6 +37,30 @@ class TestPmp < Fbe::Test
     refute(Fbe.pmp(loog: Loog::NULL).communications.stealth)
   end
 
+  def test_reads_true_boolean_default
+    $fb = Factbase.new
+    $global = {}
+    $options = Judges::Options.new
+    $loog = Loog::NULL
+    xml = <<~XML
+      <?xml version='1.0'?>
+      <pmp>
+        <area name="communications">
+          <p>
+            <name>stealth</name>
+            <default>true</default>
+            <type>bool</type>
+            <memo>Test boolean default</memo>
+          </p>
+        </area>
+      </pmp>
+    XML
+    File.stub(:read, xml) do
+      assert(Fbe.pmp(loog: Loog::NULL).communications.stealth)
+      assert(Fbe.pmp(loog: Loog::NULL).communications.stealth.value)
+    end
+  end
+
   def test_converts_to_correct_type
     $fb = Factbase.new
     $global = {}


### PR DESCRIPTION
Summary:
- Preserve boolean PMP defaults that are already coerced before final type conversion.
- Add a regression with a PMP XML bool default of true and no factbase override.

Closes #481

Validation:
- Pre-fix probe with in-memory PMP XML default true returned value=false.
- Post-fix probe with the same fixture returned value=true.
- bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/fbe/test_pmp\"; ARGV.delete(\"--no-cov\")" -> 9 tests, 17 assertions, 0 failures, 0 errors, 0 skips.
- bundle exec rake test -> 284 tests, 804 assertions, 0 failures, 0 errors, 9 skips.
- bundle exec rubocop -> 65 files inspected, no offenses detected.
- git diff --cached --check -> passed.
- gitleaks protect --staged --no-banner --redact --verbose -> no leaks found.

No secrets were added.