### PR TITLE
#477: Stop over when search quota is low

### DIFF
--- a/lib/fbe/over.rb
+++ b/lib/fbe/over.rb
@@ -26,6 +26,10 @@ def Fbe.over?(
     loog.info('We are off GitHub quota, time to stop')
     return true
   end
+  if quota_aware && Fbe.octo(loog:, options:, global:).off_quota?(resource: :search, threshold: 10)
+    loog.info('We are off GitHub Search API quota, time to stop')
+    return true
+  end
   if lifetime_aware && options.lifetime && Time.now - epoch > options.lifetime * 0.9
     loog.info("We ran out of lifetime (#{epoch.ago} already), must stop here")
     return true

--- a/test/fbe/test_over.rb
+++ b/test/fbe/test_over.rb
@@ -24,6 +24,23 @@ class TestOver < Fbe::Test
     end
   end
 
+  def test_check_search_off_quota_enabled
+    global = {}
+    options = Judges::Options.new({ 'testing' => true })
+    loog = Loog::NULL
+    octo = Fbe.octo(loog:, options:, global:)
+    calls = []
+    octo.define_singleton_method(:off_quota?) do |*args, **kwargs|
+      kwargs = args.last if kwargs.empty? && args.last.is_a?(Hash)
+      call = { threshold: kwargs[:threshold], resource: kwargs.fetch(:resource, :core) }
+      calls << call
+      call[:resource] == :search
+    end
+    assert(Fbe.over?(global:, options:, loog:, quota_aware: true))
+    assert_includes(calls, { threshold: 100, resource: :core })
+    assert_includes(calls, { threshold: 10, resource: :search })
+  end
+
   def test_check_off_quota_disabled
     global = {}
     options = Judges::Options.new({ 'testing' => true })


### PR DESCRIPTION
This PR makes `Fbe.over?` stop when the GitHub Search API quota is below the same quota-aware guard used for core quota.

The current core check remains unchanged. When core quota is still healthy, `Fbe.over?` now also checks `off_quota?(resource: :search, threshold: 10)` and returns `true` if search quota is already low.

Validation:
- RED before implementation: standalone regression returned `{:result=>false, :calls=>[{:threshold=>100, :resource=>:core}]}` and raised `expected Fbe.over? to stop on search quota`.
- GREEN after implementation: standalone regression returned `{:result=>true, :calls=>[{:threshold=>100, :resource=>:core}, {:threshold=>10, :resource=>:search}]}`.
- `ruby -e "gem 'minitest', '6.0.6'; gem 'minitest-mock', '5.27.0'; load 'test/fbe/test_over.rb'"` passed: 8 tests, 12 assertions.
- `rubocop lib/fbe/over.rb test/fbe/test_over.rb`
- `ruby -c lib/fbe/over.rb; ruby -c test/fbe/test_over.rb`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached | gitleaks stdin --no-banner --redact`

Limitation: I did not claim a full `bundle exec rake test` run in this fresh Windows worktree because Bundler cannot materialize the locked native `psych 5.3.1` dependency here.
