### PR TITLE
#458: render both between bounds

### DIFF
--- a/lib/fbe/award.rb
+++ b/lib/fbe/award.rb
@@ -253,7 +253,7 @@ class Fbe::Award
       when :min
         "minimum of #{to_p(@operands[0])} and #{to_p(@operands[1])}"
       when :between
-        "at least #{to_p(@operands[0])} and at most #{to_p(@operands[1])}"
+        "#{to_p(@operands[0])} clamped between #{to_p(@operands[1])} and #{to_p(@operands[2])}"
       else
         raise(Fbe::Error, "Unknown term '#{@op}'")
       end

--- a/test/fbe/test_award.rb
+++ b/test/fbe/test_award.rb
@@ -114,6 +114,11 @@ class TestAward < Fbe::Test
     end
   end
 
+  def test_between_bylaw_mentions_value_and_both_bounds
+    md = Fbe::Award.new('(award (set b (between b 3 120)))').bylaw.markdown
+    assert_includes(md, 'set _b_ to _b_ clamped between **3** and **120**', md)
+  end
+
   def test_shorten_when_one_number
     g = Fbe::Award.new('(award (give 23 "for love"))').bill.greeting
     assert_equal('You\'ve earned +23 points. ', g, g)


### PR DESCRIPTION
﻿Fixes #458.

The bylaw printer for `between` treated the clamped value as the lower bound and omitted the upper bound. This changes the rendering to describe the value and both bounds: `_b_ clamped between **3** and **120**`.

Currentness and duplicate checks:
- Issue #458 is open, labeled `bug` and `help wanted`, and unassigned.
- `gh pr list --repo zerocracy/fbe --state all --search "458 OR between upper bound PTerm Award"` returned no PRs.
- Broader PR searches for `PTerm between` and `clamped between` returned no PRs.
- The same-scope issue search returned only #458.

Validation:
- New regression failed before the patch with markdown saying `set _b_ to at least _b_ and at most **3**`.
- `ruby -e "gem 'minitest', '6.0.6'; gem 'minitest-mock', '5.27.0'; load 'test/fbe/test_award.rb'"` passed: 8 tests, 43 assertions.
- `rubocop lib/fbe/award.rb test/fbe/test_award.rb` passed with no offenses.
- `ruby -c lib/fbe/award.rb; ruby -c test/fbe/test_award.rb` passed.
- `git diff --check` and `git diff --cached --check` passed.
- `git diff --cached | gitleaks stdin --no-banner --redact` reported no leaks.

Limitations:
- `bundle exec rake test TEST=test/fbe/test_award.rb` is locally blocked on this Windows checkout because Bundler cannot find locked gems `rdoc-7.2.0`, `psych-5.3.1`, and `parallel-2.0.1`, and the environment also lacks `grep` on PATH. The focused direct Ruby test above was run instead.
