### PR TITLE
#469: Preserve hash additions in place

### DIFF
--- a/lib/fbe/overwrite.rb
+++ b/lib/fbe/overwrite.rb
@@ -40,14 +40,24 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
       before[k.to_s] = fact[k]
     end
     modified = false
+    missing = true
     property_or_hash.each do |k, vv|
       raise(Fbe::Error, "The value for #{k} is nil") if vv.nil?
       vv = [vv] unless vv.is_a?(Array)
+      missing = false unless before[k.to_s].nil?
       next if before[k.to_s] == vv
       before[k.to_s] = vv
       modified = true
     end
     return fact unless modified
+    if missing
+      before.slice(*property_or_hash.keys.map(&:to_s)).each do |k, vv|
+        vv.each do |v|
+          fact.public_send(:"#{k}=", v)
+        end
+      end
+      return
+    end
     id = fact[fid]&.first
     raise(Fbe::Error, "There is no #{fid} in the fact, cannot use Fbe.overwrite") if id.nil?
     raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?

--- a/test/fbe/test_overwrite.rb
+++ b/test/fbe/test_overwrite.rb
@@ -88,6 +88,22 @@ class TestOverwrite < Fbe::Test # rubocop:disable Metrics/ClassLength
     assert_equal(before, fbx.query('(eq bar 44)').each.first._id)
   end
 
+  def test_hash_without_previous_property
+    c = 0
+    fb =
+      Factbase::Pre.new(Factbase.new) do |f, _fbt|
+        f.pos = c
+        c += 1
+      end
+    f = fb.insert
+    f._id = 1
+    f.foo = 42
+    before = f.pos
+    Fbe.overwrite(f, { bar: 44 }, fb:)
+    found = fb.query('(eq bar 44)').each.first
+    assert_equal(before, found.pos)
+  end
+
   def test_safe_insert
     fb = Factbase.new
     first = fb.insert


### PR DESCRIPTION
Fixes #469.

`Fbe.overwrite` already updates scalar-form absent properties on the existing fact. The hash form did not have the same absent-property path, so adding `{ bar: 44 }` destroyed and reinserted the fact even when all requested properties were missing.

This change keeps the destroy/reinsert path for existing-property hash updates, but assigns the all-absent hash properties directly on the current fact. The regression test pins that identity-preserving behavior with `Factbase::Pre`.

Validation:
- `ruby -c lib/fbe/overwrite.rb` -> `Syntax OK`
- `ruby -c test/fbe/test_overwrite.rb` -> `Syntax OK`
- origin/master manual repro -> `PASS origin/master reproduces issue: before pos=0, after pos=1`
- candidate manual repro -> `PASS hash absent property preserved pos=0, foo=42, bar=44`
- existing-property hash path repro -> `PASS existing-property hash path recreated pos=1, foo=55, bar=44, keep=yes`
- `git diff --check origin/master...HEAD` -> no output
- `git diff origin/master...HEAD -- lib/fbe/overwrite.rb test/fbe/test_overwrite.rb | gitleaks stdin --no-banner --redact` -> `no leaks found`
- GitHub Actions on this PR are green: `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `rake` on Ubuntu/macOS Ruby 3.3, `reuse`, `typos`, `xcop`, and `yamllint`.

Limitations:
- `bundle exec ruby -Itest test/fbe/test_overwrite.rb` and `bundle exec rubocop lib/fbe/overwrite.rb test/fbe/test_overwrite.rb` were blocked in this Windows environment because Bundler was missing locked gems (`rdoc 7.2.0`, `psych 5.3.1`, `parallel 2.0.1`), and installing `psych 5.3.1` failed due missing `yaml.h` / MSYS2 keyring errors.
- non-bundled `rubocop lib/fbe/overwrite.rb test/fbe/test_overwrite.rb` reported one unchanged pre-existing warning at `test/fbe/test_overwrite.rb:16` for `Lint/RedundantCopDisableDirective`.