### PR TITLE
#458: Correct PTerm#to_s for :between operator to include all three operands

### DIFF
--- a/lib/fbe/award.rb
+++ b/lib/fbe/award.rb
@@ -253,7 +253,7 @@ class Fbe::Award
       when :min
         "minimum of #{to_p(@operands[0])} and #{to_p(@operands[1])}"
       when :between
-        "at least #{to_p(@operands[0])} and at most #{to_p(@operands[1])}"
+        "#{to_p(@operands[0])} clamped between #{to_p(@operands[1])} and #{to_p(@operands[2])}"
       else
         raise(Fbe::Error, "Unknown term '#{@op}'")
       end

--- a/test/fbe/test_award.rb
+++ b/test/fbe/test_award.rb
@@ -114,6 +114,12 @@ class TestAward < Fbe::Test
     end
   end
 
+  def test_between_in_bylaw_markdown
+    a = Fbe::Award.new('(award (set b (between x 3 120)) (give b "test"))')
+    md = a.bylaw.markdown
+    assert_includes(md, '_x_ clamped between **3** and **120**', md)
+  end
+
   def test_shorten_when_one_number
     g = Fbe::Award.new('(award (give 23 "for love"))').bill.greeting
     assert_equal('You\'ve earned +23 points. ', g, g)


### PR DESCRIPTION
## Description

`PTerm#to_s` (bylaw printer) for the `:between` operator only referenced two operands, but `BTerm#calc` (calculator) uses three:

```
@operands[0] — value being clamped
@operands[1] — min bound
@operands[2] — max bound
```

The old code on `lib/fbe/award.rb:255-256`:

```ruby
when :between
  "at least #{to_p(@operands[0])} and at most #{to_p(@operands[1])}"
```

This caused two bugs:
1. `@operands[0]` (the value being clamped) was mislabeled as a bound
2. `@operands[2]` (the upper bound) was silently dropped

For a real bylaw expression such as `(set b2 (between b2 3 120))`, the rendered markdown read: `"set b2 to at least b2 and at most 3"` — the value `b2` was described as the lower bound and the real upper bound `120` was missing.

## Fix

Changed `lib/fbe/award.rb:255-256` to:

```ruby
when :between
  "#{to_p(@operands[0])} clamped between #{to_p(@operands[1])} and #{to_p(@operands[2])}"
```

This correctly renders `(between b2 3 120)` as `_b₂_ clamped between **3** and **120**`.

## Tests

- Existing tests all pass (they only tested calculation, not rendering)
- Added `test_between_in_bylaw_markdown` — a regression test that asserts the rendered markdown of a `between` expression

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 284 tests, 0 failures

Closes #458