### PR TITLE
#473: Make total_releases_published use conditional after cursor

### DIFF
--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -490,11 +490,12 @@ class Fbe::Graph # rubocop:disable Metrics/ClassLength
     total = 0
     cursor = nil
     loop do
+      after = "after: \"#{cursor}\", " unless cursor.nil?
       result = query(
         <<~GRAPHQL
           {
             repository(owner: "#{owner}", name: "#{name}") {
-              releases(first: 25, after: "#{cursor}", orderBy: { field: CREATED_AT, direction: DESC }) {
+              releases(#{after}first: 25, orderBy: { field: CREATED_AT, direction: DESC }) {
                 nodes {
                   isDraft
                   publishedAt

--- a/test/fbe/test_github_graph.rb
+++ b/test/fbe/test_github_graph.rb
@@ -315,4 +315,17 @@ class TestGitHubGraph < Fbe::Test
     graph.pull_request_reviews('foo', 'bar', pulls: [[2, nil]])
     refute_includes(captured, 'after: ""')
   end
+
+  def test_total_releases_published_omits_after_when_cursor_is_nil
+    WebMock.disable_net_connect!
+    graph = Fbe::Graph.new(token: 'fake')
+    captured = nil
+    page = { 'nodes' => [], 'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil } }
+    graph.define_singleton_method(:query) do |qry|
+      captured = qry
+      { 'repository' => { 'releases' => page } }
+    end
+    graph.total_releases_published('foo', 'bar', Time.parse('2025-08-01T18:00:00Z'))
+    refute_includes(captured, 'after: ""')
+  end
 end


### PR DESCRIPTION
## Description

`total_releases_published` in `lib/fbe/github_graph.rb:497` always interpolates `after: "#{cursor}"` in the GraphQL query. When `cursor` is `nil` (first page), this produces `after: ""` — an invalid pagination cursor.

This is the same bug that PR #444 fixed for `pull_requests_with_reviews` and `pull_request_reviews`, but `total_releases_published` was missed.

## Fix

Applied the same conditional interpolation pattern used by three sibling methods (`total_commits_pushed`, `pull_requests_with_reviews`, `pull_request_reviews`):

```ruby
after = "after: \"#{cursor}\", " unless cursor.nil?
```

Changed the query from:
```graphql
releases(first: 25, after: "#{cursor}", orderBy: ...)
```
to:
```graphql
releases(#{after}first: 25, orderBy: ...)
```

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 283 tests, 0 failures

Closes #473