### PR TITLE
#479: Add missing 'since' DSL method to Fbe::Iterate

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -148,6 +148,24 @@ class Fbe::Iterate
     @repeats = repeats
   end
 
+  # Sets the initial value for iteration tracking.
+  #
+  # This value is used as the starting point when no marker exists in the
+  # factbase for the current iteration label. It is also used as the
+  # restart value when a query returns nil, causing the iteration for
+  # that repository to begin again from this value.
+  #
+  # @param [Integer] value The initial value for iteration tracking
+  # @return [nil] Nothing is returned
+  # @raise [RuntimeError] If value is nil or not an Integer
+  # @example Start iteration from issue number 100
+  #   iterator.since(100)
+  def since(value)
+    raise(Fbe::Error, 'Cannot set "since" to nil') if value.nil?
+    raise(Fbe::Error, 'The "since" must be an Integer') unless value.is_a?(Integer)
+    @since = value
+  end
+
   # Sets the query to execute for each iteration.
   #
   # The query can use two special variables:

--- a/test/fbe/test_iterate.rb
+++ b/test/fbe/test_iterate.rb
@@ -432,6 +432,24 @@ class TestIterate < Fbe::Test
     assert_equal(12, fb.query('(eq what "iterate")').each.to_a.first.marker)
   end
 
+  def test_custom_since
+    opts = Judges::Options.new(['repositories=foo/bar', 'testing=true'])
+    fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
+    10.times { |i| fb.insert.num = i + 1 }
+    results = []
+    Fbe.iterate(fb:, loog: Loog::NULL, options: opts, global: {}, epoch: Time.now, kickoff: Time.now) do
+      as('since_test')
+      by('(agg (and (gt num $before) (lte num 10)) (min num))')
+      since(5)
+      repeats(10)
+      over do |_, num|
+        results << num
+        num
+      end
+    end
+    assert_equal([6, 7, 8, 9, 10], results)
+  end
+
   def test_catch_fbe_off_quota_exception_correctly
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
## Description

`Fbe::Iterate` documents a `since` DSL keyword in the YARD doc for the `over` method (lines 210, 218, 227), but no such method exists. `@since` is hardcoded to `0` and users have no way to customize the starting iteration value.

## Fix

Added a `since(value)` DSL setter to `Fbe::Iterate` following the same pattern as `repeats`:

```ruby
def since(value)
  raise(Fbe::Error, 'Cannot set "since" to nil') if value.nil?
  raise(Fbe::Error, 'The "since" must be an Integer') unless value.is_a?(Integer)
  @since = value
end
```

The method:
- Accepts an Integer (same type as what the `over` block must return)
- Raises on nil (like `repeats`)
- Raises on non-Integer (type safety)
- Can be set multiple times (like `repeats`)
- Default remains `0` for backward compatibility

## Tests

Added `test_custom_since` — a regression test that uses `since(5)` and verifies iteration correctly starts from that value, processing facts in ascending order from the custom start point.

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 284 tests, 0 failures

Closes #479