### PR TITLE
#477: Check both core and search API quotas in Fbe.over?

### DIFF
--- a/lib/fbe/over.rb
+++ b/lib/fbe/over.rb
@@ -24,7 +24,7 @@ def Fbe.over?(
 )
   if quota_aware
     octo = Fbe.octo(loog:, options:, global:)
-    if octo.off_quota?(threshold: 100, resource: :core) || octo.off_quota?(threshold: 100, resource: :search)
+    if octo.off_quota?(threshold: 100, resource: :core) || octo.off_quota?(resource: :search)
       loog.info('We are off GitHub quota, time to stop')
       return true
     end

--- a/lib/fbe/over.rb
+++ b/lib/fbe/over.rb
@@ -22,9 +22,12 @@ def Fbe.over?(
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now,
   quota_aware: true, lifetime_aware: true, timeout_aware: true
 )
-  if quota_aware && Fbe.octo(loog:, options:, global:).off_quota?(threshold: 100)
-    loog.info('We are off GitHub quota, time to stop')
-    return true
+  if quota_aware
+    octo = Fbe.octo(loog:, options:, global:)
+    if octo.off_quota?(threshold: 100, resource: :core) || octo.off_quota?(threshold: 100, resource: :search)
+      loog.info('We are off GitHub quota, time to stop')
+      return true
+    end
   end
   if lifetime_aware && options.lifetime && Time.now - epoch > options.lifetime * 0.9
     loog.info("We ran out of lifetime (#{epoch.ago} already), must stop here")

--- a/test/fbe/test_over.rb
+++ b/test/fbe/test_over.rb
@@ -38,7 +38,7 @@ class TestOver < Fbe::Test
     options = Judges::Options.new({ 'testing' => true })
     loog = Loog::NULL
     octo = Fbe.octo(loog:, options:, global:)
-    def octo.off_quota?(threshold: nil, resource: :core)
+    def octo.off_quota?(resource: :core, **)
       resource == :search
     end
     assert(Fbe.over?(global:, options:, loog:, quota_aware: true))

--- a/test/fbe/test_over.rb
+++ b/test/fbe/test_over.rb
@@ -33,6 +33,17 @@ class TestOver < Fbe::Test
     end
   end
 
+  def test_search_quota_stops_run_when_core_has_quota
+    global = {}
+    options = Judges::Options.new({ 'testing' => true })
+    loog = Loog::NULL
+    octo = Fbe.octo(loog:, options:, global:)
+    def octo.off_quota?(threshold: nil, resource: :core)
+      resource == :search
+    end
+    assert(Fbe.over?(global:, options:, loog:, quota_aware: true))
+  end
+
   def test_check_lifetime_enabled
     global = {}
     options = Judges::Options.new({ 'testing' => true, 'lifetime' => 100 })


### PR DESCRIPTION
## Description

`Fbe.over?` only checks the GitHub core API quota by calling `off_quota?(threshold: 100)` with the default `resource: :core`. Judges that primarily use the Search API (e.g., searching for repositories) can continue running even after the search quota is exhausted, wasting API calls and causing errors.

## Fix

Check both `:core` and `:search` resources in `Fbe.over?`:

```ruby
octo = Fbe.octo(loog:, options:, global:)
if octo.off_quota?(threshold: 100, resource: :core) || octo.off_quota?(threshold: 100, resource: :search)
```

The `off_quota?` method already supports `resource: :search` (added in PR #448). For search quota, it reads the search remaining count from `last_response.body` and falls back to core remaining with a warning when the search count is unavailable.

The second `off_quota?` call benefits from `faraday-http-cache`, so no extra API call is made — both checks use the same cached `/rate_limit` response.

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 283 tests, 0 failures

Closes #477