### PR TITLE
#258: Add HoC threshold boundary tests for code-contribution bylaw

### DIFF
--- a/test/fbe/test_bylaws.rb
+++ b/test/fbe/test_bylaws.rb
@@ -76,6 +76,10 @@ class TestBylaws < Fbe::Test
         { hoc: 150, comments: 5, reviews: 1 } => 24,
         { hoc: 500, comments: 25, reviews: 2 } => 4,
         { hoc: 99, comments: 6, reviews: 1 } => 16,
+        { hoc: 200, comments: 0, reviews: 1 } => 8,
+        { hoc: 542, comments: 0, reviews: 1 } => 8,
+        { hoc: 799, comments: 0, reviews: 1 } => 8,
+        { hoc: 800, comments: 0, reviews: 1 } => 4,
         { hoc: 1_500, comments: 3, reviews: 0 } => 4,
         { hoc: 15_000, comments: 40, reviews: 0 } => 4
       },


### PR DESCRIPTION
## Description

Issue #258 reported that a PR with 542 hits-of-code incorrectly triggered the "-16 for surpassing 800 hits-of-code" penalty. After investigation, the calculation logic in `code-contribution-was-rewarded` bylaw is correct with default parameters (`anger=2, love=2, paranoia=2`):

- `hoc < 200`: bonus proportional to hoc, no penalty
- `200 <= hoc < 800`: no bonus, penalty -8
- `hoc >= 800`: no bonus, penalties -8 and -16

The `between` function in `award.rb` correctly returns 0 when `v < min && !v.negative?`, preventing bonus when hoc exceeds the threshold.

## Fix

Added explicit boundary test cases for the `code-contribution-was-rewarded` bylaw at both threshold boundaries (200 and 800 hoc):

| hoc | reviews | expected total | what it tests |
|-----|---------|----------------|---------------|
| 200 | 1 | 8 | First penalty kicks in at threshold boundary |
| 542 | 1 | 8 | Exact scenario from issue #258 |
| 799 | 1 | 8 | No second penalty (just below second threshold) |
| 800 | 1 | 4 | Second penalty kicks in at second threshold boundary |

All tests use `reviews: 1` to exclude the no-review penalty, isolating the HoC calculation.

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 283 tests, 0 failures

Closes #258