### PR TITLE
#450: Sync @remaining from real API response headers to prevent drift

### DIFF
--- a/lib/fbe/middleware/rate_limit.rb
+++ b/lib/fbe/middleware/rate_limit.rb
@@ -44,8 +44,12 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
     if env.url.path == '/rate_limit'
       @lock.synchronize { handle_rate_limit_request(env) }
     else
-      @lock.synchronize { track_request(env.url.path) }
-      @app.call(env)
+      @lock.synchronize do
+        track_request(env.url.path)
+        @app.call(env).on_complete do |response_env|
+          sync(response_env)
+        end
+      end
     end
   end
 
@@ -76,6 +80,24 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
     elsif @remaining.positive?
       @remaining -= 1
     end
+  end
+
+  # Syncs the internal remaining count from a real API response header.
+  #
+  # When the response was served by Faraday::HttpCache from cache
+  # (indicated by +http_cache_trace+ containing +:fresh+), the
+  # +x-ratelimit-remaining+ header is stale, so we keep our
+  # decremented count. When the API was actually contacted,
+  # we prefer the authoritative header value.
+  #
+  # @param [Faraday::Env] response_env The response environment
+  def sync(response_env)
+    return if response_env[:http_cache_trace]&.include?(:fresh)
+    headers = response_env.response_headers
+    return unless headers
+    core = headers['x-ratelimit-remaining']
+    return unless core
+    @remaining = Integer(core)
   end
 
   # Extracts the remaining count from the response body.

--- a/lib/fbe/middleware/rate_limit.rb
+++ b/lib/fbe/middleware/rate_limit.rb
@@ -44,11 +44,9 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
     if env.url.path == '/rate_limit'
       @lock.synchronize { handle_rate_limit_request(env) }
     else
-      @lock.synchronize do
-        track_request(env.url.path)
-        @app.call(env).on_complete do |response_env|
-          sync(response_env)
-        end
+      @lock.synchronize { track_request(env.url.path) }
+      @app.call(env).on_complete do |response_env|
+        @lock.synchronize { sync(response_env, env.url.path) }
       end
     end
   end
@@ -91,13 +89,17 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
   # we prefer the authoritative header value.
   #
   # @param [Faraday::Env] response_env The response environment
-  def sync(response_env)
+  def sync(response_env, path = nil)
     return if response_env[:http_cache_trace]&.include?(:fresh)
     headers = response_env.response_headers
     return unless headers
-    core = headers['x-ratelimit-remaining']
-    return unless core
-    @remaining = Integer(core)
+    remaining = headers['x-ratelimit-remaining']
+    return unless remaining
+    if path&.start_with?('/search/')
+      @searchleft = Integer(remaining)
+    else
+      @remaining = Integer(remaining)
+    end
   end
 
   # Extracts the remaining count from the response body.

--- a/test/fbe/middleware/test_rate_limit.rb
+++ b/test/fbe/middleware/test_rate_limit.rb
@@ -281,6 +281,46 @@ class RateLimitTest < Fbe::Test
     assert_requested(:get, 'https://api.github.com/rate_limit', times: 1)
   end
 
+  def test_syncs_core_remaining_from_response_header
+    payload = { 'rate' => { 'limit' => 5000, 'remaining' => 4999, 'reset' => 1_672_531_200 } }
+    stub_request(:get, 'https://api.github.com/rate_limit')
+      .to_return(status: 200, body: payload.to_json, headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://api.github.com/user')
+      .to_return(
+        status: 200, body: '{"login":"x"}', headers: {
+          'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '4900'
+        }
+      )
+    conn = create_connection
+    conn.get('/rate_limit')
+    conn.get('/user')
+    response = conn.get('/rate_limit')
+    assert_equal(4900, response.body['rate']['remaining'])
+  end
+
+  def test_syncs_search_remaining_from_response_header
+    payload = {
+      'rate' => { 'limit' => 5000, 'remaining' => 4999, 'reset' => 1_672_531_200 },
+      'resources' => {
+        'core' => { 'limit' => 5000, 'remaining' => 4999, 'reset' => 1_672_531_200 },
+        'search' => { 'limit' => 30, 'remaining' => 30, 'reset' => 1_672_531_200 }
+      }
+    }
+    stub_request(:get, 'https://api.github.com/rate_limit')
+      .to_return(status: 200, body: payload.to_json, headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://api.github.com/search/issues?q=s')
+      .to_return(
+        status: 200, body: '{"items":[]}', headers: {
+          'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '25'
+        }
+      )
+    conn = create_connection
+    conn.get('/rate_limit')
+    conn.get('/search/issues?q=s')
+    response = conn.get('/rate_limit')
+    assert_equal(25, response.body['resources']['search']['remaining'])
+  end
+
   def test_cached_body_is_not_leaked_to_callers
     payload = {
       'rate' => { 'limit' => 5000, 'remaining' => 4999, 'reset' => 1_672_531_200 },

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -731,7 +731,7 @@ class TestOcto < Fbe::Test
     octo.print_trace!(all: true, max: 9_999)
     output = loog.to_s
     assert_includes(output, '3 URLs vs 4 requests')
-    assert_includes(output, '219 quota left')
+    assert_includes(output, '222 quota left')
     assert_includes(output, '/rate_limit: 1')
     assert_includes(output, '/user/123: 1')
     assert_includes(output, '/repos/foo/bar: 2')


### PR DESCRIPTION
## Description

`Fbe::Middleware::RateLimit` tracks `@remaining` by decrementing for every non-rate_limit API call. When `Faraday::HttpCache` serves a cached response (no actual API call), the middleware still decrements `@remaining`, causing it to drift below the actual remaining count.

This means `off_quota?` (which reads `@remaining` from the middleware via `rate_limit!`) can report the quota is exhausted earlier than necessary — a false positive. While safe, this prematurely stops processing.

## Fix

After every non-cached API response, the middleware now syncs `@remaining` from the real `x-ratelimit-remaining` response header. Faraday::HttpCache sets `env[:http_cache_trace]` to indicate cache status (`:fresh` = served from cache, `:stale`/none = API was contacted). The same pattern is already used by `Fbe::Middleware::Trace` to filter cached responses.

Key changes:
- In `call()` for non-rate_limit requests, add `on_complete` callback to process the response
- New `sync(response_env)` method that reads `x-ratelimit-remaining` header from real API responses
- For cached responses (`:fresh`), the decrement fallback is preserved

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 283 tests, 0 failures
- Updated `test_print_trace` to expect header-synced count (222) instead of decremented count (219)

Closes #450