### PR TITLE
#361: Allow reading custom PMP properties from custom areas

### DIFF
--- a/lib/fbe/pmp.rb
+++ b/lib/fbe/pmp.rb
@@ -28,6 +28,13 @@ require_relative 'fb'
 #   Fbe.pmp.cost.hourly_rate
 #   Fbe.pmp.time.deadline
 #
+# Custom areas (not defined in +assets/pmp.xml+) are also supported. When
+# accessing a property through a custom area, the returned value is read
+# directly from the factbase without XML defaults or type coercion. The
+# returned +Pmpv+ object will have +nil+ for +default+, +type+, and +memo+.
+#
+#   Fbe.pmp.my_custom.my_prop  # reads from factbase, no XML defaults
+#
 # @param [Factbase] fb The factbase
 # @param [Hash] global The hash for global caching
 # @param [Judges::Options] options The options coming from the +judges+ tool
@@ -42,6 +49,9 @@ require_relative 'fb'
 #
 #   # Get deadline from time area
 #   deadline = Fbe.pmp.time.deadline
+#
+#   # Read custom property (nil default/type/memo)
+#   val = Fbe.pmp.my_custom.my_prop
 def Fbe.pmp(fb: Fbe.fb, global: $global, options: $options, loog: $loog) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   xml = Nokogiri::XML(File.read(File.join(__dir__, '../../assets/pmp.xml')))
   pmpv =

--- a/lib/fbe/pmp.rb
+++ b/lib/fbe/pmp.rb
@@ -42,7 +42,7 @@ require_relative 'fb'
 #
 #   # Get deadline from time area
 #   deadline = Fbe.pmp.time.deadline
-def Fbe.pmp(fb: Fbe.fb, global: $global, options: $options, loog: $loog) # rubocop:disable Metrics/AbcSize
+def Fbe.pmp(fb: Fbe.fb, global: $global, options: $options, loog: $loog) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   xml = Nokogiri::XML(File.read(File.join(__dir__, '../../assets/pmp.xml')))
   pmpv =
     Class.new(SimpleDelegator) do
@@ -55,6 +55,7 @@ def Fbe.pmp(fb: Fbe.fb, global: $global, options: $options, loog: $loog) # ruboc
         @memo = memo
       end
     end
+  query = ->(area) { Fbe.fb(global:, fb:, options:, loog:).query("(and (eq what 'pmp') (eq area '#{area}'))") }
   Class.new do
     define_method(:areas) do
       xml.xpath('/pmp/area/@name').map(&:value)
@@ -62,42 +63,53 @@ def Fbe.pmp(fb: Fbe.fb, global: $global, options: $options, loog: $loog) # ruboc
     others do |*args1|
       area = args1.first.to_s
       node = xml.at_xpath("/pmp/area[@name='#{area}']")
-      raise Fbe::Error, "Unknown area #{area.inspect}" if node.nil?
-      Class.new do
-        define_method(:properties) do
-          node.xpath('p/name').map(&:text)
-        end
-        others do |*args2|
-          param = args2.first.to_s
-          f = Fbe.fb(global:, fb:, options:, loog:).query("(and (eq what 'pmp') (eq area '#{area}'))").each.first
-          result = f&.[](param)&.first
-          prop = node.at_xpath("p[name='#{param}']")
-          default = nil
-          type = nil
-          memo = nil
-          if prop
-            default = prop.at_xpath('default').text
-            type = prop.at_xpath('type').text
-            memo = prop.at_xpath('memo').text
-            default =
-              case type
-              when 'int' then Integer(default, 10)
-              when 'float' then Float(default)
-              when 'bool' then default == 'true'
-              else default
-              end
+      if node.nil?
+        Class.new do
+          define_method(:properties) do
+            query.call(area).each.first&.all_properties&.map(&:to_s) || []
           end
-          result ||= default
-          result =
-            case type
-            when 'int' then Integer(Float(result).truncate)
-            when 'float' then Float(result)
-            when 'bool' then result == 'true'
-            else result
+          others do |*args2|
+            param = args2.first.to_s
+            result = query.call(area).each.first&.[](param)&.first
+            pmpv.new(result, nil, nil, nil)
+          end
+        end.new
+      else
+        Class.new do
+          define_method(:properties) do
+            node.xpath('p/name').map(&:text)
+          end
+          others do |*args2|
+            param = args2.first.to_s
+            result = query.call(area).each.first&.[](param)&.first
+            prop = node.at_xpath("p[name='#{param}']")
+            default = nil
+            type = nil
+            memo = nil
+            if prop
+              default = prop.at_xpath('default').text
+              type = prop.at_xpath('type').text
+              memo = prop.at_xpath('memo').text
+              default =
+                case type
+                when 'int' then Integer(default, 10)
+                when 'float' then Float(default)
+                when 'bool' then default == 'true'
+                else default
+                end
             end
-          pmpv.new(result, default, type, memo)
-        end
-      end.new
+            result ||= default
+            result =
+              case type
+              when 'int' then Integer(Float(result).truncate)
+              when 'float' then Float(result)
+              when 'bool' then result == 'true'
+              else result
+              end
+            pmpv.new(result, default, type, memo)
+          end
+        end.new
+      end
     end
   end.new
 end

--- a/test/fbe/test_pmp.rb
+++ b/test/fbe/test_pmp.rb
@@ -98,9 +98,39 @@ class TestPmp < Fbe::Test
     assert(Fbe.pmp(loog: Loog::NULL).communications.stealth.value)
   end
 
-  def test_fail_on_wrong_area
+  def test_custom_area
     $global = {}
+    $options = Judges::Options.new
     $loog = Loog::NULL
-    assert_raises(StandardError) { Fbe.pmp(Factbase.new, loog: Loog::NULL).something }
+    fb = Fbe.fb(fb: Factbase.new, global: $global, options: $options, loog: $loog)
+    f = fb.insert
+    f.what = 'pmp'
+    f.area = 'custom'
+    f.my_prop = 42
+    assert_equal(42, Fbe.pmp(fb:, loog: Loog::NULL).custom.my_prop)
+  end
+
+  def test_custom_area_without_fact
+    $global = {}
+    $options = Judges::Options.new
+    $loog = Loog::NULL
+    fb = Factbase.new
+    v = Fbe.pmp(fb:, loog: Loog::NULL).custom.my_prop
+    assert_nil(v.value)
+  end
+
+  def test_custom_area_properties
+    $global = {}
+    $options = Judges::Options.new
+    $loog = Loog::NULL
+    $fb = Factbase.new
+    f = $fb.insert
+    f.what = 'pmp'
+    f.area = 'custom'
+    f.prop_a = 1
+    f.prop_b = 2
+    props = Fbe.pmp(loog: Loog::NULL).custom.properties
+    assert_includes(props, 'prop_a')
+    assert_includes(props, 'prop_b')
   end
 end


### PR DESCRIPTION
## Description

`Fbe.pmp` only allows accessing properties through areas defined in `assets/pmp.xml`. When a PMP fact has a custom area (not in the XML), accessing it via `Fbe.pmp.custom_area.my_prop` raises "Unknown area":

```ruby
# This worked (area "hr" is in pmp.xml):
Fbe.pmp.hr.days_to_reward  # => 14 (from XML default)

# This raised (area "my_custom" is NOT in pmp.xml):
Fbe.pmp.my_custom.my_prop  # => "Unknown area 'my_custom'"
```

## Fix

When an area is not found in `pmp.xml`, fall back to reading properties directly from the factbase without XML defaults or type coercion. This allows custom PMP properties to be accessed:

```ruby
f = fb.insert
f.what = 'pmp'
f.area = 'my_custom'
f.my_prop = 42
Fbe.pmp.my_custom.my_prop  # => 42 (now works)
```

Built-in areas with XML definitions continue to work as before with defaults and type coercion.

## Tests

- `test_custom_area` — verifies custom property is readable via custom area
- `test_custom_area_without_fact` — verifies nil value when no fact exists
- `test_custom_area_properties` — verifies `properties` method lists custom props

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 285 tests, 0 failures

Closes #361