### PR TITLE
#509: preserve multi-valued follow properties in Conclude#fill

### DIFF
--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -247,8 +247,11 @@ class Fbe::Conclude
   #   end
   def fill(fact, prev)
     @follows.each do |follow|
-      v = prev.public_send(follow)
-      fact.public_send(:"#{follow}=", v)
+      values = prev[follow.to_s]
+      next if values.nil?
+      values.each do |v|
+        fact.public_send(:"#{follow}=", v)
+      end
     end
     r = yield(fact, prev)
     return unless r.is_a?(String)

--- a/test/fbe/test_conclude.rb
+++ b/test/fbe/test_conclude.rb
@@ -50,6 +50,29 @@ class TestConclude < Fbe::Test
     assert_includes(f.details, 'funny')
   end
 
+  def test_draw_follow_preserves_multi_values
+    $fb = Factbase.new
+    $global = {}
+    $epoch = Time.now
+    $loog = Loog::NULL
+    $options = Judges::Options.new
+    $fb.insert.then do |f|
+      f.win = 1
+      f.win = 2
+      f.win = 3
+    end
+    Fbe.conclude(judge: 'judge-multi') do
+      quota_unaware
+      on('(exists win)')
+      follow('win')
+      draw do |_n, _prev|
+        nil
+      end
+    end
+    f = $fb.query('(exists win)').each.to_a.last
+    assert_equal([1, 2, 3], f['win'])
+  end
+
   def test_draw_with_rollback
     $fb = Factbase.new
     $global = {}


### PR DESCRIPTION
The `follow` DSL keyword in `Fbe::Conclude` is documented as copying named properties from the seen fact to the drawn fact (see the `follow 'win when'` example in the class docstring), but `Fbe::Conclude#fill` was reading each property with `prev.public_send(follow)`, which on `Factbase::Fact` returns only the first value of a multi-valued property. Any property carrying more than one value was silently truncated to its first value during a `draw`. `Fbe.copy` already handles the multi-valued case correctly by iterating over `source[k]`; this change brings `fill` in line with that.

The new fact now keeps every value the source carried for each followed property, with a `nil` source value treated as a no-op rather than an error.

Verified locally with `bundle exec ruby -Itest test/fbe/test_conclude.rb` (11 tests, 13 assertions, all green, including the new `test_draw_follow_preserves_multi_values`), `bundle exec ruby -Itest test/fbe/test_consider.rb` (green), and `rubocop lib/fbe/conclude.rb test/fbe/test_conclude.rb` (no offenses).

Closes #509
