### PR TITLE
#512: Add missing quota_aware parameter to Fbe.consider

### DIFF
--- a/lib/fbe/consider.rb
+++ b/lib/fbe/consider.rb
@@ -17,17 +17,21 @@ require_relative 'fb'
 # @param [Loog] loog The logging facility
 # @param [Time] epoch When the entire update started
 # @param [Time] kickoff When the particular judge started
+# @param [Boolean] lifetime_aware Check lifetime limitations (default: true)
+# @param [Boolean] timeout_aware Check timeout limitations (default: true)
+# @param [Boolean] quota_aware Check GitHub API quota (default: true)
 # @yield [Factbase::Fact] The fact
 def Fbe.consider(
   query,
   fb: Fbe.fb, judge: $judge, loog: $loog, options: $options, global: $global,
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now,
-  lifetime_aware: true, timeout_aware: true, &
+  lifetime_aware: true, timeout_aware: true, quota_aware: true, &
 )
   Fbe.conclude(fb:, judge:, loog:, options:, global:, epoch:, kickoff:) do
     on(query)
     timeout_unaware unless timeout_aware
     lifetime_unaware unless lifetime_aware
+    quota_unaware unless quota_aware
     consider(&)
   end
 end

--- a/test/fbe/test_consider.rb
+++ b/test/fbe/test_consider.rb
@@ -32,4 +32,22 @@ class TestConsider < Fbe::Test
     end
     assert_equal(1, $fb.size)
   end
+
+  def test_quota_unaware
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '0' } }
+    )
+    $fb = Factbase.new
+    $fb.insert.foo = 42
+    $epoch = Time.now
+    $global = {}
+    $options = Judges::Options.new
+    $loog = Loog::NULL
+    $judge = ''
+    Fbe.consider('(always)', quota_aware: false) do |f|
+      f.bar = 7
+    end
+    assert_equal(1, $fb.size)
+  end
 end


### PR DESCRIPTION
## Description

`Fbe.consider` accepts `lifetime_aware:` and `timeout_aware:` but was missing `quota_aware:`, even though `Fbe::Conclude` supports `quota_unaware` and `Fbe.over?` consults all three flags symmetrically.

## Fix

Added `quota_aware: true` to the method signature and `quota_unaware unless quota_aware` to the inner block, mirroring the two existing flags.

## Closes

Closes #512

## Tests

- `test_quota_unaware` — verifies that setting `quota_aware: false` allows processing to continue even when the GitHub API quota is exhausted

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 0 failures