### PR TITLE
#508: Prevent malformed query in kill_if when ids are empty

### DIFF
--- a/lib/fbe/kill_if.rb
+++ b/lib/fbe/kill_if.rb
@@ -19,5 +19,6 @@ def Fbe.kill_if(facts, fb: Fbe.fb, fid: '_id')
     end
     ids << f[fid].first
   end
+  return 0 if ids.empty?
   fb.query("(or #{ids.map { |id| "(eq #{fid} #{id})" }.join})").delete!
 end

--- a/test/fbe/test_kill_if.rb
+++ b/test/fbe/test_kill_if.rb
@@ -36,4 +36,17 @@ class TestKillIf < Fbe::Test
     assert_equal(1, Fbe.kill_if(fb.query('(always)').each.to_a, fb:) { |f| f.foo.zero? })
     assert_equal(1, fb.size)
   end
+
+  def test_returns_zero_when_facts_empty
+    fb = Factbase.new
+    assert_equal(0, Fbe.kill_if([], fb:))
+  end
+
+  def test_returns_zero_when_block_rejects_all
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.insert.foo = 2
+    assert_equal(0, Fbe.kill_if(fb.query('(always)').each.to_a, fb:) { false })
+    assert_equal(2, fb.size)
+  end
 end


### PR DESCRIPTION
When `kill_if` receives an empty facts array or the block rejects all facts, `ids` stays empty and the interpolated query becomes `(or )`, which is invalid.

Added early return `return 0 if ids.empty?` to match `delete!` return contract.

Closes #508

Tests:
- `test_returns_zero_when_facts_empty`
- `test_returns_zero_when_block_rejects_all`