### PR TITLE
#509: Copy all values of multi-valued follow properties in Conclude#fill

### DIFF
--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -247,8 +247,9 @@ class Fbe::Conclude
   #   end
   def fill(fact, prev)
     @follows.each do |follow|
-      v = prev.public_send(follow)
-      fact.public_send(:"#{follow}=", v)
+      prev[follow.to_s].each do |v|
+        fact.public_send(:"#{follow}=", v)
+      end
     end
     r = yield(fact, prev)
     return unless r.is_a?(String)

--- a/test/fbe/test_conclude.rb
+++ b/test/fbe/test_conclude.rb
@@ -181,6 +181,30 @@ class TestConclude < Fbe::Test
     assert_equal(42, f.score)
   end
 
+  def test_follow_multivalued
+    $fb = Factbase.new
+    $global = {}
+    $epoch = Time.now
+    $loog = Loog::NULL
+    $options = Judges::Options.new
+    f = $fb.insert
+    f.foo = 1
+    f.tags = 'a'
+    f.tags = 'b'
+    f.tags = 'c'
+    Fbe.conclude(judge: 'judge-follow') do
+      quota_unaware
+      on('(exists foo)')
+      follow('tags')
+      draw do |n, _prev|
+        n.processed = 'yes'
+        'Some long description that satisfies the twenty five chars minimum.'
+      end
+    end
+    n = $fb.query('(eq processed "yes")').each.to_a[0]
+    assert_equal(%w[a b c], n['tags'])
+  end
+
   def test_catch_fbe_off_quota_exception_correctly
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
## Description

`Fbe::Conclude#fill` used `prev.public_send(follow)` which returns only the first value of a multi-valued property. Replaced with `prev[follow.to_s].each` to copy all values, matching the contract documented by the `follow` DSL keyword.

## Fix

Changed lines 250-251 in `lib/fbe/conclude.rb` from single-value access to full iteration over all values, matching the pattern used by `Fbe.copy` in `lib/fbe/copy.rb`.

Closes #509

## Tests

- `test_follow_multivalued` — creates a fact with `tags = ['a', 'b', 'c']`, uses `follow 'tags'` in a `draw` block, and asserts the new fact retains all three values

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 0 failures