### PR TITLE
#507: Move timestamp update in Fbe.repeatedly after yield to prevent lockout on failure

### DIFF
--- a/lib/fbe/repeatedly.rb
+++ b/lib/fbe/repeatedly.rb
@@ -53,7 +53,7 @@ def Fbe.repeatedly(area, p_every_hours, fb: Fbe.fb, judge: $judge, loog: $loog, 
     f = fb.insert
     f.what = judge
   end
-  Fbe.overwrite(f, 'when', Time.now)
   yield(fb.query("(and (eq what '#{judge}'))").each.first)
+  Fbe.overwrite(f, 'when', Time.now)
   nil
 end

--- a/test/fbe/test_repeatedly.rb
+++ b/test/fbe/test_repeatedly.rb
@@ -48,4 +48,22 @@ class TestRepeatedly < Fbe::Test
     assert_includes(output, 'custom_judge')
     refute_includes(output, 'global_judge')
   end
+
+  def test_failed_block_does_not_lock_out_next_run
+    $fb = Factbase.new
+    $loog = Loog::NULL
+    $options = Judges::Options.new
+    $global = {}
+    judge = 'failing-judge'
+    assert_raises(RuntimeError) do
+      Fbe.repeatedly('pmp', 'every_x_hours', judge:) do |_f|
+        raise(RuntimeError, 'oops')
+      end
+    end
+    ran = false
+    Fbe.repeatedly('pmp', 'every_x_hours', judge:) do |_f|
+      ran = true
+    end
+    assert(ran)
+  end
 end


### PR DESCRIPTION
## Description

`Fbe.repeatedly` called `Fbe.overwrite(f, 'when', Time.now)` before yielding. If the block raised, the `when` property was already updated, causing the next call to skip execution for the entire configured interval.

## Fix

Moved `Fbe.overwrite(f, 'when', Time.now)` to after the yield. If the block fails, the timestamp is not updated and the next call will run again.

Closes #507

## Tests

- `test_failed_block_does_not_lock_out_next_run` — first call raises, second call succeeds

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 0 failures