### PR TITLE
#515: Preserve original _id in overwrite and delete_one on decorated factbases

### DIFF
--- a/lib/fbe.rb
+++ b/lib/fbe.rb
@@ -12,3 +12,15 @@ module Fbe
   VERSION = '0.0.0' unless const_defined?(:VERSION)
   class Error < StandardError; end
 end
+
+# Removes the _id property from the fact's internal map, so the recreation
+# loop can restore the original _id from the deleted fact. This is needed
+# because the +Factbase::Pre+ hook sets _id before the loop runs.
+def Fbe.unid(fact)
+  f = fact
+  while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)
+    iv = f.instance_variable_defined?(:@fact) ? :@fact : :@origin
+    f = f.instance_variable_get(iv)
+  end
+  f.instance_variable_get(:@map).delete('_id')
+end

--- a/lib/fbe/delete_one.rb
+++ b/lib/fbe/delete_one.rb
@@ -33,6 +33,7 @@ def Fbe.delete_one(fact, prop, value, fb: Fbe.fb, id: '_id')
   fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
     c = fbt.insert
+    Fbe.unid(c)
     before.each do |k, vv|
       next unless c[k].nil?
       vv.each do |v|

--- a/lib/fbe/overwrite.rb
+++ b/lib/fbe/overwrite.rb
@@ -53,6 +53,7 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
     raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
     fb.txn do |fbt|
       n = fbt.insert
+      Fbe.unid(n)
       before.each do |k, vv|
         next unless n[k].nil?
         vv.each do |v|
@@ -82,6 +83,7 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
   raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
   fb.txn do |fbt|
     n = fbt.insert
+    Fbe.unid(n)
     before[property.to_s] = values
     before.each do |k, vv|
       next unless n[k].nil?

--- a/test/fbe/test_delete_one.rb
+++ b/test/fbe/test_delete_one.rb
@@ -53,4 +53,25 @@ class TestDeleteOne < Fbe::Test
     assert_equal(1, fb.query('(exists foo)').each.to_a.size)
     assert_equal(1, fb.query('(eq foo 42)').each.to_a.size)
   end
+
+  def test_preserves_id_on_decorated_fb
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    before = target._id
+    target.foo = 42
+    target.foo = 43
+    Fbe.delete_one(target, 'foo', 42, fb: fbx)
+    after = fbx.query('(eq foo 43)').each.first
+    assert_equal(before, after._id)
+  end
 end

--- a/test/fbe/test_overwrite.rb
+++ b/test/fbe/test_overwrite.rb
@@ -358,4 +358,42 @@ class TestOverwrite < Fbe::Test
     assert_equal('Привет мир', result['russian'].first)
     assert_equal('こんにちは世界', result['japanese'].first)
   end
+
+  def test_preserves_id_on_decorated_fb
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    before = target._id
+    Fbe.overwrite(target, 'foo', 42, fb: fbx)
+    after = fbx.query('(eq foo 42)').each.first
+    assert_equal(before, after._id)
+  end
+
+  def test_preserves_id_on_decorated_fb_with_hash
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    before = target._id
+    Fbe.overwrite(target, { foo: 42 }, fb: fbx)
+    after = fbx.query('(eq foo 42)').each.first
+    assert_equal(before, after._id)
+  end
 end


### PR DESCRIPTION
## Description

`Fbe.overwrite` and `Fbe.delete_one` use delete-and-recreate when the property already exists. On a `Fbe.fb`-decorated factbase, the `Factbase::Pre` hook assigns a fresh `_id` (`(max _id) + 1`) on every insert, and the recreation loop skipped `_id` because it was already set. The original `_id` was lost, breaking external references.

## Fix

Added `Fbe.unid` helper that removes the `_id` property from the fact's internal map after the Pre hook fires but before the recreation loop runs. The loop then sees `_id` as nil and restores the original value from `before`.

Affected paths:
- `Fbe.overwrite` hash path (line 54-65)
- `Fbe.overwrite` scalar path (line 86-98)
- `Fbe.delete_one` (line 34-42)

Closes #515

## Tests

- `test_preserves_id_on_decorated_fb` — scalar overwrite on Fbe.fb-decorated factbase with 3 facts
- `test_preserves_id_on_decorated_fb_with_hash` — hash overwrite on decorated factbase
- `test_preserves_id_on_decorated_fb` (delete_one) — delete_one on decorated factbase

## Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 286 tests, 0 failures