### PR TITLE
#524: Add nil and empty string validation to Fbe.just_one

### DIFF
--- a/lib/fbe/just_one.rb
+++ b/lib/fbe/just_one.rb
@@ -38,7 +38,10 @@ def Fbe.just_one(fb: Fbe.fb)
     others(map: attrs) do |*args|
       k = args[0]
       if k.end_with?('=')
-        @map[k[0..-2].to_sym] = args[1]
+        v = args[1]
+        raise(Fbe::Error, "Can't set #{k[0..-2]} to nil") if v.nil?
+        raise(Fbe::Error, "Can't set #{k[0..-2]} to empty string") if v.is_a?(String) && v.empty?
+        @map[k[0..-2].to_sym] = v
       else
         @map[k.to_sym]
       end

--- a/test/fbe/test_just_one.rb
+++ b/test/fbe/test_just_one.rb
@@ -41,4 +41,20 @@ class TestJustOne < Fbe::Test
       end
     refute_nil(n)
   end
+
+  def test_raises_on_empty_value
+    assert_raises(StandardError) do
+      Fbe.just_one(fb: Factbase.new) do |f|
+        f.foo = ''
+      end
+    end
+  end
+
+  def test_raises_on_nil
+    assert_raises(StandardError) do
+      Fbe.just_one(fb: Factbase.new) do |f|
+        f.foo = nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

`Fbe.just_one` at `lib/fbe/just_one.rb:41` sets property values without validation. `nil` and empty strings are silently accepted, while the factbase gem only allows `String`, `Integer`, `Float`, `Time`. `Fbe.if_absent` already validates these cases.

## Fix

Added guards for `nil` and empty `String` values, matching the pattern in `lib/fbe/if_absent.rb:57-58`.