### PR TITLE
#523: Dup value before in-place mutation in SqliteStore

### DIFF
--- a/lib/fbe/middleware/sqlite_store.rb
+++ b/lib/fbe/middleware/sqlite_store.rb
@@ -106,7 +106,7 @@ class Fbe::Middleware::SqliteStore
   # @return [nil]
   # @note Values larger than 10KB are not cached
   # @note Non-GET requests and URLs with query parameters are not cached
-  def write(key, value) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def write(key, value) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
     return if value.is_a?(Array) && value.any? do |vv|
       req = JSON.parse(vv[0])
       req['method'] != 'get'

--- a/lib/fbe/middleware/sqlite_store.rb
+++ b/lib/fbe/middleware/sqlite_store.rb
@@ -129,6 +129,8 @@ class Fbe::Middleware::SqliteStore
           end
         end
         resp['response_headers']['cache-control'] = control
+        value = value.dup
+        value[0] = value[0].dup
         value[0][1] = JSON.dump(resp)
       end
     end

--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -393,6 +393,16 @@ class SqliteStoreTest < Fbe::Test
     end
   end
 
+  def test_does_not_mutate_original_value
+    with_tmpfile('x.db') do |f|
+      store = Fbe::Middleware::SqliteStore.new(f, '0.0.1', loog: fake_loog, cache_min_age: 300)
+      original = faraday_value(resp: { 'response_headers' => { 'cache-control' => 'public, max-age=60' } })
+      prior = original[0][1].dup
+      store.write('test', original)
+      assert_equal(prior, original[0][1], 'original value must not be mutated')
+    end
+  end
+
   def test_overwrite_cache_control
     with_tmpfile('t.db') do |f|
       Fbe::Middleware::SqliteStore.new(f, '0.0.1', loog: fake_loog, cache_min_age: 300).then do |store|


### PR DESCRIPTION
## Description

`lib/fbe/middleware/sqlite_store.rb:132-133` performs `value[0][1] = JSON.dump(resp)` which mutates the array in-place. When `Faraday::HttpCache` passes a frozen or shared structure, this can cause `FrozenError` or silently corrupt the caller's data.

## Fix

Added `.dup` on the mutable containers before writing.