### PR TITLE
#527: Thread-safe global caching with GLOBAL_MUTEX

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,11 @@ Elegant/GoodMethodName:
     - workflow_run
     - workflow_run_job
     - workflow_run_usage
+Elegant/GoodVariableName:
+  AllowedNames:
+    - '@fb_mutex'
+    - '@octo_mutex'
+    - '@graph_mutex'
 Naming/MethodParameterName:
   AllowedNames:
     - as

--- a/lib/fbe.rb
+++ b/lib/fbe.rb
@@ -11,5 +11,4 @@
 module Fbe
   VERSION = '0.0.0' unless const_defined?(:VERSION)
   class Error < StandardError; end
-  GLOBAL_MUTEX = Mutex.new
 end

--- a/lib/fbe.rb
+++ b/lib/fbe.rb
@@ -11,4 +11,5 @@
 module Fbe
   VERSION = '0.0.0' unless const_defined?(:VERSION)
   class Error < StandardError; end
+  GLOBAL_MUTEX = Mutex.new
 end

--- a/lib/fbe/fb.rb
+++ b/lib/fbe/fb.rb
@@ -31,34 +31,36 @@ def Fbe.fb(fb: $fb, global: $global, options: $options, loog: $loog)
   raise(Fbe::Error, 'The $global is not set') if global.nil?
   raise(Fbe::Error, 'The $options is not set') if options.nil?
   raise(Fbe::Error, 'The $loog is not set') if loog.nil?
-  global[:fb] ||=
-    begin
-      rules = Dir.glob(File.join(File.join(__dir__, '../../rules'), '*.fe')).map { |f| File.read(f) }
-      fbe = Factbase::Rules.new(
-        fb,
-        "(and \n#{rules.join("\n")}\n)",
-        uid: '_id'
-      )
-      fbe =
-        Factbase::Pre.new(fbe) do |f, fbt|
-          max = fbt.query('(max _id)').one
-          f._id = (max.nil? ? 0 : max) + 1
-          f._time = Time.now
-          f._version = [Factbase::VERSION, Judges::VERSION, options.action_version].compact.join('/')
-          f._job = Integer(options.job_id.to_s, 10) if options.job_id
-        end
-      Factbase::Impatient.new(
-        Factbase::Logged.new(
-          Factbase::SyncFactbase.new(
-            Factbase::IndexedFactbase.new(
-              Factbase::CachedFactbase.new(
-                fbe
+  Fbe::GLOBAL_MUTEX.synchronize do
+    global[:fb] ||=
+      begin
+        rules = Dir.glob(File.join(File.join(__dir__, '../../rules'), '*.fe')).map { |f| File.read(f) }
+        fbe = Factbase::Rules.new(
+          fb,
+          "(and \n#{rules.join("\n")}\n)",
+          uid: '_id'
+        )
+        fbe =
+          Factbase::Pre.new(fbe) do |f, fbt|
+            max = fbt.query('(max _id)').one
+            f._id = (max.nil? ? 0 : max) + 1
+            f._time = Time.now
+            f._version = [Factbase::VERSION, Judges::VERSION, options.action_version].compact.join('/')
+            f._job = Integer(options.job_id.to_s, 10) if options.job_id
+          end
+        Factbase::Impatient.new(
+          Factbase::Logged.new(
+            Factbase::SyncFactbase.new(
+              Factbase::IndexedFactbase.new(
+                Factbase::CachedFactbase.new(
+                  fbe
+                )
               )
-            )
+            ),
+            loog
           ),
-          loog
-        ),
-        timeout: 60
-      )
-    end
+          timeout: 60
+        )
+      end
+  end
 end

--- a/lib/fbe/fb.rb
+++ b/lib/fbe/fb.rb
@@ -13,6 +13,7 @@ require 'factbase/rules'
 require 'factbase/sync/sync_factbase'
 require 'judges'
 require 'loog'
+require 'monitor'
 require_relative '../fbe'
 
 # Returns an instance of +Factbase+ (cached).
@@ -26,41 +27,45 @@ require_relative '../fbe'
 # @param [Judges::Options] options The options coming from the +judges+ tool
 # @param [Loog] loog The logging facility
 # @return [Factbase] The global factbase
-def Fbe.fb(fb: $fb, global: $global, options: $options, loog: $loog)
-  raise(Fbe::Error, 'The fb is nil') if fb.nil?
-  raise(Fbe::Error, 'The $global is not set') if global.nil?
-  raise(Fbe::Error, 'The $options is not set') if options.nil?
-  raise(Fbe::Error, 'The $loog is not set') if loog.nil?
-  Fbe::GLOBAL_MUTEX.synchronize do
-    global[:fb] ||=
-      begin
-        rules = Dir.glob(File.join(File.join(__dir__, '../../rules'), '*.fe')).map { |f| File.read(f) }
-        fbe = Factbase::Rules.new(
-          fb,
-          "(and \n#{rules.join("\n")}\n)",
-          uid: '_id'
-        )
-        fbe =
-          Factbase::Pre.new(fbe) do |f, fbt|
-            max = fbt.query('(max _id)').one
-            f._id = (max.nil? ? 0 : max) + 1
-            f._time = Time.now
-            f._version = [Factbase::VERSION, Judges::VERSION, options.action_version].compact.join('/')
-            f._job = Integer(options.job_id.to_s, 10) if options.job_id
-          end
-        Factbase::Impatient.new(
-          Factbase::Logged.new(
-            Factbase::SyncFactbase.new(
-              Factbase::IndexedFactbase.new(
-                Factbase::CachedFactbase.new(
-                  fbe
+module Fbe
+  @fb_mutex = Monitor.new
+
+  def self.fb(fb: $fb, global: $global, options: $options, loog: $loog)
+    raise(Fbe::Error, 'The fb is nil') if fb.nil?
+    raise(Fbe::Error, 'The $global is not set') if global.nil?
+    raise(Fbe::Error, 'The $options is not set') if options.nil?
+    raise(Fbe::Error, 'The $loog is not set') if loog.nil?
+    @fb_mutex.synchronize do
+      global[:fb] ||=
+        begin
+          rules = Dir.glob(File.join(File.join(__dir__, '../../rules'), '*.fe')).map { |f| File.read(f) }
+          fbe = Factbase::Rules.new(
+            fb,
+            "(and \n#{rules.join("\n")}\n)",
+            uid: '_id'
+          )
+          fbe =
+            Factbase::Pre.new(fbe) do |f, fbt|
+              max = fbt.query('(max _id)').one
+              f._id = (max.nil? ? 0 : max) + 1
+              f._time = Time.now
+              f._version = [Factbase::VERSION, Judges::VERSION, options.action_version].compact.join('/')
+              f._job = Integer(options.job_id.to_s, 10) if options.job_id
+            end
+          Factbase::Impatient.new(
+            Factbase::Logged.new(
+              Factbase::SyncFactbase.new(
+                Factbase::IndexedFactbase.new(
+                  Factbase::CachedFactbase.new(
+                    fbe
+                  )
                 )
-              )
+              ),
+              loog
             ),
-            loog
-          ),
-          timeout: 60
-        )
-      end
+            timeout: 60
+          )
+        end
+    end
   end
 end

--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -6,6 +6,7 @@
 require 'graphql/client'
 require 'graphql/client/http'
 require 'loog'
+require 'monitor'
 require_relative '../fbe'
 
 # Creates an instance of {Fbe::Graph}.
@@ -14,15 +15,19 @@ require_relative '../fbe'
 # @param [Hash] global Hash of global options
 # @param [Loog] loog Logging facility
 # @return [Fbe::Graph] The instance of the class
-def Fbe.github_graph(options: $options, global: $global, loog: $loog)
-  Fbe::GLOBAL_MUTEX.synchronize do
-    global[:github_graph] ||=
-      if options.testing.nil?
-        Fbe::Graph.new(token: options.github_token || ENV.fetch('GITHUB_TOKEN', nil))
-      else
-        loog.debug('The connection to GitHub GraphQL API is mocked')
-        Fbe::Graph::Fake.new
-      end
+module Fbe
+  @graph_mutex = Monitor.new
+
+  def self.github_graph(options: $options, global: $global, loog: $loog)
+    @graph_mutex.synchronize do
+      global[:github_graph] ||=
+        if options.testing.nil?
+          Fbe::Graph.new(token: options.github_token || ENV.fetch('GITHUB_TOKEN', nil))
+        else
+          loog.debug('The connection to GitHub GraphQL API is mocked')
+          Fbe::Graph::Fake.new
+        end
+    end
   end
 end
 

--- a/lib/fbe/github_graph.rb
+++ b/lib/fbe/github_graph.rb
@@ -15,13 +15,15 @@ require_relative '../fbe'
 # @param [Loog] loog Logging facility
 # @return [Fbe::Graph] The instance of the class
 def Fbe.github_graph(options: $options, global: $global, loog: $loog)
-  global[:github_graph] ||=
-    if options.testing.nil?
-      Fbe::Graph.new(token: options.github_token || ENV.fetch('GITHUB_TOKEN', nil))
-    else
-      loog.debug('The connection to GitHub GraphQL API is mocked')
-      Fbe::Graph::Fake.new
-    end
+  Fbe::GLOBAL_MUTEX.synchronize do
+    global[:github_graph] ||=
+      if options.testing.nil?
+        Fbe::Graph.new(token: options.github_token || ENV.fetch('GITHUB_TOKEN', nil))
+      else
+        loog.debug('The connection to GitHub GraphQL API is mocked')
+        Fbe::Graph::Fake.new
+      end
+  end
 end
 
 # A client to GitHub GraphQL.

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -11,6 +11,7 @@ require 'filesize'
 require 'intercepted'
 require 'json'
 require 'loog'
+require 'monitor'
 require 'obk'
 require 'octokit'
 require 'others'
@@ -46,213 +47,218 @@ Fbe::SEARCH_METHODS = %i[
 # @param [Hash] global Hash of global options
 # @param [Loog] loog Logging facility
 # @return [Hash] Usually returns a JSON, as it comes from the GitHub API
-def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-  Fbe::GLOBAL_MUTEX.synchronize do # rubocop:disable Metrics/BlockLength
+module Fbe
+  @octo_mutex = Monitor.new
+
+  def self.octo(options: $options, global: $global, loog: $loog) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     raise(Fbe::Error, 'The $global is not set') if global.nil?
     raise(Fbe::Error, 'The $options is not set') if options.nil?
     raise(Fbe::Error, 'The $loog is not set') if loog.nil?
-    global[:octo] ||=
-      begin
-        loog.info("Fbe version is #{Fbe::VERSION}")
-        trace = []
-        if options.testing.nil?
-          o = Octokit::Client.new
-          token = options.github_token
-          if token.nil?
-            loog.debug("The 'github_token' option is not provided")
-            token = ENV.fetch('GITHUB_TOKEN', nil)
+    @octo_mutex.synchronize do # rubocop:disable Metrics/BlockLength
+      global[:octo] ||=
+        begin
+          loog.info("Fbe version is #{Fbe::VERSION}")
+          trace = []
+          if options.testing.nil?
+            o = Octokit::Client.new
+            token = options.github_token
             if token.nil?
-              loog.debug("The 'GITHUB_TOKEN' environment variable is not set")
+              loog.debug("The 'github_token' option is not provided")
+              token = ENV.fetch('GITHUB_TOKEN', nil)
+              if token.nil?
+                loog.debug("The 'GITHUB_TOKEN' environment variable is not set")
+              else
+                loog.debug("The 'GITHUB_TOKEN' environment was provided")
+              end
             else
-              loog.debug("The 'GITHUB_TOKEN' environment was provided")
+              loog.debug("The 'github_token' option was provided (#{token.length} chars)")
             end
-          else
-            loog.debug("The 'github_token' option was provided (#{token.length} chars)")
-          end
-          if token.nil?
-            loog.warn('Accessing GitHub API without a token!')
-          elsif token.empty?
-            loog.warn('The GitHub API token is an empty string, won\'t use it')
-          else
-            o = Octokit::Client.new(access_token: token)
-          end
-          o.auto_paginate = true
-          o.per_page = 100
-          o.connection_options = { request: { open_timeout: 15, timeout: 15 } }
-          stack =
-            Faraday::RackBuilder.new do |builder|
-              builder.use(
-                Faraday::Retry::Middleware,
-                exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [
-                  Octokit::TooManyRequests, Octokit::ServiceUnavailable
-                ],
-                max: 4,
-                interval: ENV['RACK_ENV'] == 'test' ? 0.01 : 4,
-                methods: [:get],
-                backoff_factor: 2
+            if token.nil?
+              loog.warn('Accessing GitHub API without a token!')
+            elsif token.empty?
+              loog.warn('The GitHub API token is an empty string, won\'t use it')
+            else
+              o = Octokit::Client.new(access_token: token)
+            end
+            o.auto_paginate = true
+            o.per_page = 100
+            o.connection_options = { request: { open_timeout: 15, timeout: 15 } }
+            stack =
+              Faraday::RackBuilder.new do |builder|
+                builder.use(
+                  Faraday::Retry::Middleware,
+                  exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [
+                    Octokit::TooManyRequests, Octokit::ServiceUnavailable
+                  ],
+                  max: 4,
+                  interval: ENV['RACK_ENV'] == 'test' ? 0.01 : 4,
+                  methods: [:get],
+                  backoff_factor: 2
+                )
+                builder.use(Octokit::Response::RaiseError)
+                builder.use(Faraday::Response::Logger, loog, formatter: Fbe::Middleware::Formatter)
+                builder.use(Fbe::Middleware::RateLimit)
+                builder.use(Fbe::Middleware::Trace, trace, ignores: [:fresh])
+                if options.sqlite_cache
+                  maxsize = Integer(Filesize.from(options.sqlite_cache_maxsize || '100M'))
+                  maxvsize = Integer(Filesize.from(options.sqlite_cache_maxvsize || '100K'))
+                  minage = options.sqlite_cache_min_age.nil? ? nil : Integer(options.sqlite_cache_min_age.to_s, 10)
+                  store = Fbe::Middleware::SqliteStore.new(
+                    options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24, cache_min_age: minage
+                  )
+                  sz = File.exist?(store.path) ? Filesize.from(File.size(store.path).to_s).pretty : 'file is absent'
+                  loog.info(
+                    "Using HTTP cache in SQLite file: #{store.path} (#{sz}, " \
+                    "max size: #{Filesize.from(maxsize.to_s).pretty}, " \
+                    "max vsize: #{Filesize.from(maxvsize.to_s).pretty})"
+                  )
+                  builder.use(Faraday::HttpCache, store:, serializer: JSON, shared_cache: false, logger: Loog::NULL)
+                else
+                  loog.info("No HTTP cache in SQLite file, because 'sqlite_cache' option is not provided")
+                  builder.use(Faraday::HttpCache, serializer: Marshal, shared_cache: false, logger: Loog::NULL)
+                end
+                builder.adapter(Faraday.default_adapter)
+              end
+            o.middleware = stack
+            o = Verbose.new(o, log: loog)
+            unless token.nil? || token.empty?
+              loog.info(
+                "Accessing GitHub API with a token (#{token.length} chars, ending by #{token[-4..].inspect}, " \
+                "#{o.rate_limit.remaining} quota remaining)"
               )
-              builder.use(Octokit::Response::RaiseError)
-              builder.use(Faraday::Response::Logger, loog, formatter: Fbe::Middleware::Formatter)
-              builder.use(Fbe::Middleware::RateLimit)
-              builder.use(Fbe::Middleware::Trace, trace, ignores: [:fresh])
-              if options.sqlite_cache
-                maxsize = Integer(Filesize.from(options.sqlite_cache_maxsize || '100M'))
-                maxvsize = Integer(Filesize.from(options.sqlite_cache_maxvsize || '100K'))
-                minage = options.sqlite_cache_min_age.nil? ? nil : Integer(options.sqlite_cache_min_age.to_s, 10)
-                store = Fbe::Middleware::SqliteStore.new(
-                  options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24, cache_min_age: minage
-                )
-                loog.info(
-                  "Using HTTP cache in SQLite file: #{store.path} (" \
-                  "#{File.exist?(store.path) ? Filesize.from(File.size(store.path).to_s).pretty : 'file is absent'}, " \
-                  "max size: #{Filesize.from(maxsize.to_s).pretty}, max vsize: #{Filesize.from(maxvsize.to_s).pretty})"
-                )
-                builder.use(Faraday::HttpCache, store:, serializer: JSON, shared_cache: false, logger: Loog::NULL)
-              else
-                loog.info("No HTTP cache in SQLite file, because 'sqlite_cache' option is not provided")
-                builder.use(Faraday::HttpCache, serializer: Marshal, shared_cache: false, logger: Loog::NULL)
-              end
-              builder.adapter(Faraday.default_adapter)
             end
-          o.middleware = stack
-          o = Verbose.new(o, log: loog)
-          unless token.nil? || token.empty?
-            loog.info(
-              "Accessing GitHub API with a token (#{token.length} chars, ending by #{token[-4..].inspect}, " \
-              "#{o.rate_limit.remaining} quota remaining)"
-            )
+          else
+            loog.debug('The connection to GitHub API is mocked')
+            o = Fbe::FakeOctokit.new
           end
-        else
-          loog.debug('The connection to GitHub API is mocked')
-          o = Fbe::FakeOctokit.new
-        end
-        o =
-          decoor(o, loog:, trace:) do # rubocop:disable Metrics/BlockLength
-            def print_trace!(all: false, max: 5)
-              if @trace.empty?
-                @loog.debug('GitHub API trace is empty')
-              else
-                grouped =
-                  @trace.select { |e| e[:duration] > 0.05 || all }.group_by do |entry|
-                    uri = URI.parse(entry[:url])
-                    query = uri.query
-                    query = "?#{query.ellipsized(40)}" if query
-                    "#{uri.scheme}://#{uri.host}#{uri.path}#{query}"
-                  end
-                message = grouped
-                  .sort_by { |_path, entries| -entries.count }
-                  .map do |path, entries|
-                    [
-                      '  ',
-                      path.gsub(%r{^https://api.github.com/}, '/'),
-                      ': ',
-                      entries.count,
-                      " (#{entries.sum { |e| e[:duration] }.seconds})"
-                    ].join
-                  end
-                  .take(max)
-                  .join("\n")
-                @loog.info(
-                  "GitHub API trace (#{grouped.count} URLs vs #{@trace.count} requests, " \
-                  "#{@origin.rate_limit!.remaining} quota left):\n#{message}"
-                )
-                @trace.clear
-              end
-            end
-            def off_quota?(threshold: nil, resource: :core) # rubocop:disable Layout/EmptyLineBetweenDefs, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-              threshold ||= resource == :search ? 5 : 50
-              label = resource == :search ? 'GitHub Search API' : 'GitHub API'
-              left = @origin.rate_limit!.remaining
-              got = false
-              if resource == :search && @origin.respond_to?(:last_response)
-                body = @origin.last_response&.body
-                body = JSON.parse(body) if body.is_a?(String)
-                if body.is_a?(Hash)
-                  fresh = body.dig('resources', 'search', 'remaining') || body.dig(:resources, :search, :remaining)
-                  if fresh
-                    left = Integer(fresh)
-                    got = true
-                  end
+          o =
+            decoor(o, loog:, trace:) do # rubocop:disable Metrics/BlockLength
+              def print_trace!(all: false, max: 5)
+                if @trace.empty?
+                  @loog.debug('GitHub API trace is empty')
+                else
+                  grouped =
+                    @trace.select { |e| e[:duration] > 0.05 || all }.group_by do |entry|
+                      uri = URI.parse(entry[:url])
+                      query = uri.query
+                      query = "?#{query.ellipsized(40)}" if query
+                      "#{uri.scheme}://#{uri.host}#{uri.path}#{query}"
+                    end
+                  message = grouped
+                    .sort_by { |_path, entries| -entries.count }
+                    .map do |path, entries|
+                      [
+                        '  ',
+                        path.gsub(%r{^https://api.github.com/}, '/'),
+                        ': ',
+                        entries.count,
+                        " (#{entries.sum { |e| e[:duration] }.seconds})"
+                      ].join
+                    end
+                    .take(max)
+                    .join("\n")
+                  @loog.info(
+                    "GitHub API trace (#{grouped.count} URLs vs #{@trace.count} requests, " \
+                    "#{@origin.rate_limit!.remaining} quota left):\n#{message}"
+                  )
+                  @trace.clear
                 end
               end
-              if resource == :search && !got
-                klass = @origin.respond_to?(:last_response) ? @origin.last_response&.body&.class : nil
-                @loog.warn(
-                  "Search-quota check fell back to core remaining (#{left}); " \
-                  "search count unavailable (last_response body class: #{klass.inspect})"
-                )
+              def off_quota?(threshold: nil, resource: :core) # rubocop:disable Layout/EmptyLineBetweenDefs, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+                threshold ||= resource == :search ? 5 : 50
+                label = resource == :search ? 'GitHub Search API' : 'GitHub API'
+                left = @origin.rate_limit!.remaining
+                got = false
+                if resource == :search && @origin.respond_to?(:last_response)
+                  body = @origin.last_response&.body
+                  body = JSON.parse(body) if body.is_a?(String)
+                  if body.is_a?(Hash)
+                    fresh = body.dig('resources', 'search', 'remaining') || body.dig(:resources, :search, :remaining)
+                    if fresh
+                      left = Integer(fresh)
+                      got = true
+                    end
+                  end
+                end
+                if resource == :search && !got
+                  klass = @origin.respond_to?(:last_response) ? @origin.last_response&.body&.class : nil
+                  @loog.warn(
+                    "Search-quota check fell back to core remaining (#{left}); " \
+                    "search count unavailable (last_response body class: #{klass.inspect})"
+                  )
+                end
+                if left < threshold
+                  @loog.info("Too much #{label} quota consumed already (#{left} < #{threshold})")
+                  true
+                else
+                  @loog.debug("Still #{left} #{label} quota left (>#{threshold})")
+                  false
+                end
               end
-              if left < threshold
-                @loog.info("Too much #{label} quota consumed already (#{left} < #{threshold})")
-                true
-              else
-                @loog.debug("Still #{left} #{label} quota left (>#{threshold})")
-                false
+              def user_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
+                raise(Fbe::Error, 'The ID of the user is nil') if id.nil?
+                raise(Fbe::Error, 'The ID of the user must be an Integer') unless id.is_a?(Integer)
+                json = @origin.user(id)
+                name = json[:login].downcase
+                @loog.debug("GitHub user ##{id} has a name: @#{name}")
+                name
+              end
+              def repo_id_by_name(name) # rubocop:disable Layout/EmptyLineBetweenDefs
+                raise(Fbe::Error, 'The name of the repo is nil') if name.nil?
+                json = @origin.repository(name)
+                id = json[:id]
+                raise(Fbe::Error, "Repository #{name} not found") if id.nil?
+                @loog.debug("GitHub repository #{name.inspect} has an ID: ##{id}")
+                id
+              end
+              def repo_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
+                raise(Fbe::Error, 'The ID of the repo is nil') if id.nil?
+                raise(Fbe::Error, 'The ID of the repo must be an Integer') unless id.is_a?(Integer)
+                json = @origin.repository(id)
+                name = json[:full_name].downcase
+                @loog.debug("GitHub repository ##{id} has a name: #{name}")
+                name
+              end
+              # Disable auto pagination for octokit client called in block
+              #
+              # @yield [octo] Give octokit client with disabled auto pagination
+              # @yieldparam [Octokit::Client, Fbe::FakeOctokit] Octokit client
+              # @return [Object] Last value in block
+              # @example
+              #   issue =
+              #      Fbe.octo.with_disable_auto_paginate do |octo|
+              #        octo.list_issue('zerocracy/fbe', per_page: 1).first
+              #      end
+              def with_disable_auto_paginate # rubocop:disable Layout/EmptyLineBetweenDefs
+                ap = @origin.auto_paginate
+                @origin.auto_paginate = false
+                yield(self) if block_given?
+              ensure
+                @origin.auto_paginate = ap
               end
             end
-            def user_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
-              raise(Fbe::Error, 'The ID of the user is nil') if id.nil?
-              raise(Fbe::Error, 'The ID of the user must be an Integer') unless id.is_a?(Integer)
-              json = @origin.user(id)
-              name = json[:login].downcase
-              @loog.debug("GitHub user ##{id} has a name: @#{name}")
-              name
+          o =
+            intercepted(o) do |e, m, _args, _r|
+              next unless e == :before
+              next if %i[off_quota? print_trace! rate_limit].include?(m)
+              if Fbe::SEARCH_METHODS.include?(m)
+                raise(Fbe::OffQuota, "We are off-quota on the search resource, can't do #{m}()") if
+                  o.off_quota?(resource: :search)
+              elsif o.off_quota?
+                raise(Fbe::OffQuota, "We are off-quota (remaining: #{o.rate_limit.remaining}), can't do #{m}()")
+              end
             end
-            def repo_id_by_name(name) # rubocop:disable Layout/EmptyLineBetweenDefs
-              raise(Fbe::Error, 'The name of the repo is nil') if name.nil?
-              json = @origin.repository(name)
-              id = json[:id]
-              raise(Fbe::Error, "Repository #{name} not found") if id.nil?
-              @loog.debug("GitHub repository #{name.inspect} has an ID: ##{id}")
-              id
+          o.instance_eval do
+            def send(...)
+              __send__(...)
             end
-            def repo_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
-              raise(Fbe::Error, 'The ID of the repo is nil') if id.nil?
-              raise(Fbe::Error, 'The ID of the repo must be an Integer') unless id.is_a?(Integer)
-              json = @origin.repository(id)
-              name = json[:full_name].downcase
-              @loog.debug("GitHub repository ##{id} has a name: #{name}")
-              name
-            end
-            # Disable auto pagination for octokit client called in block
-            #
-            # @yield [octo] Give octokit client with disabled auto pagination
-            # @yieldparam [Octokit::Client, Fbe::FakeOctokit] Octokit client
-            # @return [Object] Last value in block
-            # @example
-            #   issue =
-            #      Fbe.octo.with_disable_auto_paginate do |octo|
-            #        octo.list_issue('zerocracy/fbe', per_page: 1).first
-            #      end
-            def with_disable_auto_paginate # rubocop:disable Layout/EmptyLineBetweenDefs
-              ap = @origin.auto_paginate
-              @origin.auto_paginate = false
-              yield(self) if block_given?
-            ensure
-              @origin.auto_paginate = ap
+            def public_send(...) # rubocop:disable Layout/EmptyLineBetweenDefs, Elegant/GoodMethodName
+              __send__(...)
             end
           end
-        o =
-          intercepted(o) do |e, m, _args, _r|
-            next unless e == :before
-            next if %i[off_quota? print_trace! rate_limit].include?(m)
-            if Fbe::SEARCH_METHODS.include?(m)
-              raise(Fbe::OffQuota, "We are off-quota on the search resource, can't do #{m}()") if
-                o.off_quota?(resource: :search)
-            elsif o.off_quota?
-              raise(Fbe::OffQuota, "We are off-quota (remaining: #{o.rate_limit.remaining}), can't do #{m}()")
-            end
-          end
-        o.instance_eval do
-          def send(...)
-            __send__(...)
-          end
-          def public_send(...) # rubocop:disable Layout/EmptyLineBetweenDefs, Elegant/GoodMethodName
-            __send__(...)
-          end
+          o
         end
-        o
-      end
+    end
   end
 end
 

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -47,211 +47,213 @@ Fbe::SEARCH_METHODS = %i[
 # @param [Loog] loog Logging facility
 # @return [Hash] Usually returns a JSON, as it comes from the GitHub API
 def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-  raise(Fbe::Error, 'The $global is not set') if global.nil?
-  raise(Fbe::Error, 'The $options is not set') if options.nil?
-  raise(Fbe::Error, 'The $loog is not set') if loog.nil?
-  global[:octo] ||=
-    begin
-      loog.info("Fbe version is #{Fbe::VERSION}")
-      trace = []
-      if options.testing.nil?
-        o = Octokit::Client.new
-        token = options.github_token
-        if token.nil?
-          loog.debug("The 'github_token' option is not provided")
-          token = ENV.fetch('GITHUB_TOKEN', nil)
+  Fbe::GLOBAL_MUTEX.synchronize do # rubocop:disable Metrics/BlockLength
+    raise(Fbe::Error, 'The $global is not set') if global.nil?
+    raise(Fbe::Error, 'The $options is not set') if options.nil?
+    raise(Fbe::Error, 'The $loog is not set') if loog.nil?
+    global[:octo] ||=
+      begin
+        loog.info("Fbe version is #{Fbe::VERSION}")
+        trace = []
+        if options.testing.nil?
+          o = Octokit::Client.new
+          token = options.github_token
           if token.nil?
-            loog.debug("The 'GITHUB_TOKEN' environment variable is not set")
+            loog.debug("The 'github_token' option is not provided")
+            token = ENV.fetch('GITHUB_TOKEN', nil)
+            if token.nil?
+              loog.debug("The 'GITHUB_TOKEN' environment variable is not set")
+            else
+              loog.debug("The 'GITHUB_TOKEN' environment was provided")
+            end
           else
-            loog.debug("The 'GITHUB_TOKEN' environment was provided")
+            loog.debug("The 'github_token' option was provided (#{token.length} chars)")
           end
-        else
-          loog.debug("The 'github_token' option was provided (#{token.length} chars)")
-        end
-        if token.nil?
-          loog.warn('Accessing GitHub API without a token!')
-        elsif token.empty?
-          loog.warn('The GitHub API token is an empty string, won\'t use it')
-        else
-          o = Octokit::Client.new(access_token: token)
-        end
-        o.auto_paginate = true
-        o.per_page = 100
-        o.connection_options = { request: { open_timeout: 15, timeout: 15 } }
-        stack =
-          Faraday::RackBuilder.new do |builder|
-            builder.use(
-              Faraday::Retry::Middleware,
-              exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [
-                Octokit::TooManyRequests, Octokit::ServiceUnavailable
-              ],
-              max: 4,
-              interval: ENV['RACK_ENV'] == 'test' ? 0.01 : 4,
-              methods: [:get],
-              backoff_factor: 2
+          if token.nil?
+            loog.warn('Accessing GitHub API without a token!')
+          elsif token.empty?
+            loog.warn('The GitHub API token is an empty string, won\'t use it')
+          else
+            o = Octokit::Client.new(access_token: token)
+          end
+          o.auto_paginate = true
+          o.per_page = 100
+          o.connection_options = { request: { open_timeout: 15, timeout: 15 } }
+          stack =
+            Faraday::RackBuilder.new do |builder|
+              builder.use(
+                Faraday::Retry::Middleware,
+                exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [
+                  Octokit::TooManyRequests, Octokit::ServiceUnavailable
+                ],
+                max: 4,
+                interval: ENV['RACK_ENV'] == 'test' ? 0.01 : 4,
+                methods: [:get],
+                backoff_factor: 2
+              )
+              builder.use(Octokit::Response::RaiseError)
+              builder.use(Faraday::Response::Logger, loog, formatter: Fbe::Middleware::Formatter)
+              builder.use(Fbe::Middleware::RateLimit)
+              builder.use(Fbe::Middleware::Trace, trace, ignores: [:fresh])
+              if options.sqlite_cache
+                maxsize = Integer(Filesize.from(options.sqlite_cache_maxsize || '100M'))
+                maxvsize = Integer(Filesize.from(options.sqlite_cache_maxvsize || '100K'))
+                minage = options.sqlite_cache_min_age.nil? ? nil : Integer(options.sqlite_cache_min_age.to_s, 10)
+                store = Fbe::Middleware::SqliteStore.new(
+                  options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24, cache_min_age: minage
+                )
+                loog.info(
+                  "Using HTTP cache in SQLite file: #{store.path} (" \
+                  "#{File.exist?(store.path) ? Filesize.from(File.size(store.path).to_s).pretty : 'file is absent'}, " \
+                  "max size: #{Filesize.from(maxsize.to_s).pretty}, max vsize: #{Filesize.from(maxvsize.to_s).pretty})"
+                )
+                builder.use(Faraday::HttpCache, store:, serializer: JSON, shared_cache: false, logger: Loog::NULL)
+              else
+                loog.info("No HTTP cache in SQLite file, because 'sqlite_cache' option is not provided")
+                builder.use(Faraday::HttpCache, serializer: Marshal, shared_cache: false, logger: Loog::NULL)
+              end
+              builder.adapter(Faraday.default_adapter)
+            end
+          o.middleware = stack
+          o = Verbose.new(o, log: loog)
+          unless token.nil? || token.empty?
+            loog.info(
+              "Accessing GitHub API with a token (#{token.length} chars, ending by #{token[-4..].inspect}, " \
+              "#{o.rate_limit.remaining} quota remaining)"
             )
-            builder.use(Octokit::Response::RaiseError)
-            builder.use(Faraday::Response::Logger, loog, formatter: Fbe::Middleware::Formatter)
-            builder.use(Fbe::Middleware::RateLimit)
-            builder.use(Fbe::Middleware::Trace, trace, ignores: [:fresh])
-            if options.sqlite_cache
-              maxsize = Integer(Filesize.from(options.sqlite_cache_maxsize || '100M'))
-              maxvsize = Integer(Filesize.from(options.sqlite_cache_maxvsize || '100K'))
-              minage = options.sqlite_cache_min_age.nil? ? nil : Integer(options.sqlite_cache_min_age.to_s, 10)
-              store = Fbe::Middleware::SqliteStore.new(
-                options.sqlite_cache, Fbe::VERSION, loog:, maxsize:, maxvsize:, ttl: 24, cache_min_age: minage
-              )
-              loog.info(
-                "Using HTTP cache in SQLite file: #{store.path} (" \
-                "#{File.exist?(store.path) ? Filesize.from(File.size(store.path).to_s).pretty : 'file is absent'}, " \
-                "max size: #{Filesize.from(maxsize.to_s).pretty}, max vsize: #{Filesize.from(maxvsize.to_s).pretty})"
-              )
-              builder.use(Faraday::HttpCache, store:, serializer: JSON, shared_cache: false, logger: Loog::NULL)
-            else
-              loog.info("No HTTP cache in SQLite file, because 'sqlite_cache' option is not provided")
-              builder.use(Faraday::HttpCache, serializer: Marshal, shared_cache: false, logger: Loog::NULL)
-            end
-            builder.adapter(Faraday.default_adapter)
           end
-        o.middleware = stack
-        o = Verbose.new(o, log: loog)
-        unless token.nil? || token.empty?
-          loog.info(
-            "Accessing GitHub API with a token (#{token.length} chars, ending by #{token[-4..].inspect}, " \
-            "#{o.rate_limit.remaining} quota remaining)"
-          )
+        else
+          loog.debug('The connection to GitHub API is mocked')
+          o = Fbe::FakeOctokit.new
         end
-      else
-        loog.debug('The connection to GitHub API is mocked')
-        o = Fbe::FakeOctokit.new
-      end
-      o =
-        decoor(o, loog:, trace:) do # rubocop:disable Metrics/BlockLength
-          def print_trace!(all: false, max: 5)
-            if @trace.empty?
-              @loog.debug('GitHub API trace is empty')
-            else
-              grouped =
-                @trace.select { |e| e[:duration] > 0.05 || all }.group_by do |entry|
-                  uri = URI.parse(entry[:url])
-                  query = uri.query
-                  query = "?#{query.ellipsized(40)}" if query
-                  "#{uri.scheme}://#{uri.host}#{uri.path}#{query}"
-                end
-              message = grouped
-                .sort_by { |_path, entries| -entries.count }
-                .map do |path, entries|
-                  [
-                    '  ',
-                    path.gsub(%r{^https://api.github.com/}, '/'),
-                    ': ',
-                    entries.count,
-                    " (#{entries.sum { |e| e[:duration] }.seconds})"
-                  ].join
-                end
-                .take(max)
-                .join("\n")
-              @loog.info(
-                "GitHub API trace (#{grouped.count} URLs vs #{@trace.count} requests, " \
-                "#{@origin.rate_limit!.remaining} quota left):\n#{message}"
-              )
-              @trace.clear
-            end
-          end
-          def off_quota?(threshold: nil, resource: :core) # rubocop:disable Layout/EmptyLineBetweenDefs, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-            threshold ||= resource == :search ? 5 : 50
-            label = resource == :search ? 'GitHub Search API' : 'GitHub API'
-            left = @origin.rate_limit!.remaining
-            got = false
-            if resource == :search && @origin.respond_to?(:last_response)
-              body = @origin.last_response&.body
-              body = JSON.parse(body) if body.is_a?(String)
-              if body.is_a?(Hash)
-                fresh = body.dig('resources', 'search', 'remaining') || body.dig(:resources, :search, :remaining)
-                if fresh
-                  left = Integer(fresh)
-                  got = true
-                end
+        o =
+          decoor(o, loog:, trace:) do # rubocop:disable Metrics/BlockLength
+            def print_trace!(all: false, max: 5)
+              if @trace.empty?
+                @loog.debug('GitHub API trace is empty')
+              else
+                grouped =
+                  @trace.select { |e| e[:duration] > 0.05 || all }.group_by do |entry|
+                    uri = URI.parse(entry[:url])
+                    query = uri.query
+                    query = "?#{query.ellipsized(40)}" if query
+                    "#{uri.scheme}://#{uri.host}#{uri.path}#{query}"
+                  end
+                message = grouped
+                  .sort_by { |_path, entries| -entries.count }
+                  .map do |path, entries|
+                    [
+                      '  ',
+                      path.gsub(%r{^https://api.github.com/}, '/'),
+                      ': ',
+                      entries.count,
+                      " (#{entries.sum { |e| e[:duration] }.seconds})"
+                    ].join
+                  end
+                  .take(max)
+                  .join("\n")
+                @loog.info(
+                  "GitHub API trace (#{grouped.count} URLs vs #{@trace.count} requests, " \
+                  "#{@origin.rate_limit!.remaining} quota left):\n#{message}"
+                )
+                @trace.clear
               end
             end
-            if resource == :search && !got
-              klass = @origin.respond_to?(:last_response) ? @origin.last_response&.body&.class : nil
-              @loog.warn(
-                "Search-quota check fell back to core remaining (#{left}); " \
-                "search count unavailable (last_response body class: #{klass.inspect})"
-              )
+            def off_quota?(threshold: nil, resource: :core) # rubocop:disable Layout/EmptyLineBetweenDefs, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+              threshold ||= resource == :search ? 5 : 50
+              label = resource == :search ? 'GitHub Search API' : 'GitHub API'
+              left = @origin.rate_limit!.remaining
+              got = false
+              if resource == :search && @origin.respond_to?(:last_response)
+                body = @origin.last_response&.body
+                body = JSON.parse(body) if body.is_a?(String)
+                if body.is_a?(Hash)
+                  fresh = body.dig('resources', 'search', 'remaining') || body.dig(:resources, :search, :remaining)
+                  if fresh
+                    left = Integer(fresh)
+                    got = true
+                  end
+                end
+              end
+              if resource == :search && !got
+                klass = @origin.respond_to?(:last_response) ? @origin.last_response&.body&.class : nil
+                @loog.warn(
+                  "Search-quota check fell back to core remaining (#{left}); " \
+                  "search count unavailable (last_response body class: #{klass.inspect})"
+                )
+              end
+              if left < threshold
+                @loog.info("Too much #{label} quota consumed already (#{left} < #{threshold})")
+                true
+              else
+                @loog.debug("Still #{left} #{label} quota left (>#{threshold})")
+                false
+              end
             end
-            if left < threshold
-              @loog.info("Too much #{label} quota consumed already (#{left} < #{threshold})")
-              true
-            else
-              @loog.debug("Still #{left} #{label} quota left (>#{threshold})")
-              false
+            def user_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
+              raise(Fbe::Error, 'The ID of the user is nil') if id.nil?
+              raise(Fbe::Error, 'The ID of the user must be an Integer') unless id.is_a?(Integer)
+              json = @origin.user(id)
+              name = json[:login].downcase
+              @loog.debug("GitHub user ##{id} has a name: @#{name}")
+              name
+            end
+            def repo_id_by_name(name) # rubocop:disable Layout/EmptyLineBetweenDefs
+              raise(Fbe::Error, 'The name of the repo is nil') if name.nil?
+              json = @origin.repository(name)
+              id = json[:id]
+              raise(Fbe::Error, "Repository #{name} not found") if id.nil?
+              @loog.debug("GitHub repository #{name.inspect} has an ID: ##{id}")
+              id
+            end
+            def repo_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
+              raise(Fbe::Error, 'The ID of the repo is nil') if id.nil?
+              raise(Fbe::Error, 'The ID of the repo must be an Integer') unless id.is_a?(Integer)
+              json = @origin.repository(id)
+              name = json[:full_name].downcase
+              @loog.debug("GitHub repository ##{id} has a name: #{name}")
+              name
+            end
+            # Disable auto pagination for octokit client called in block
+            #
+            # @yield [octo] Give octokit client with disabled auto pagination
+            # @yieldparam [Octokit::Client, Fbe::FakeOctokit] Octokit client
+            # @return [Object] Last value in block
+            # @example
+            #   issue =
+            #      Fbe.octo.with_disable_auto_paginate do |octo|
+            #        octo.list_issue('zerocracy/fbe', per_page: 1).first
+            #      end
+            def with_disable_auto_paginate # rubocop:disable Layout/EmptyLineBetweenDefs
+              ap = @origin.auto_paginate
+              @origin.auto_paginate = false
+              yield(self) if block_given?
+            ensure
+              @origin.auto_paginate = ap
             end
           end
-          def user_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
-            raise(Fbe::Error, 'The ID of the user is nil') if id.nil?
-            raise(Fbe::Error, 'The ID of the user must be an Integer') unless id.is_a?(Integer)
-            json = @origin.user(id)
-            name = json[:login].downcase
-            @loog.debug("GitHub user ##{id} has a name: @#{name}")
-            name
+        o =
+          intercepted(o) do |e, m, _args, _r|
+            next unless e == :before
+            next if %i[off_quota? print_trace! rate_limit].include?(m)
+            if Fbe::SEARCH_METHODS.include?(m)
+              raise(Fbe::OffQuota, "We are off-quota on the search resource, can't do #{m}()") if
+                o.off_quota?(resource: :search)
+            elsif o.off_quota?
+              raise(Fbe::OffQuota, "We are off-quota (remaining: #{o.rate_limit.remaining}), can't do #{m}()")
+            end
           end
-          def repo_id_by_name(name) # rubocop:disable Layout/EmptyLineBetweenDefs
-            raise(Fbe::Error, 'The name of the repo is nil') if name.nil?
-            json = @origin.repository(name)
-            id = json[:id]
-            raise(Fbe::Error, "Repository #{name} not found") if id.nil?
-            @loog.debug("GitHub repository #{name.inspect} has an ID: ##{id}")
-            id
+        o.instance_eval do
+          def send(...)
+            __send__(...)
           end
-          def repo_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
-            raise(Fbe::Error, 'The ID of the repo is nil') if id.nil?
-            raise(Fbe::Error, 'The ID of the repo must be an Integer') unless id.is_a?(Integer)
-            json = @origin.repository(id)
-            name = json[:full_name].downcase
-            @loog.debug("GitHub repository ##{id} has a name: #{name}")
-            name
-          end
-          # Disable auto pagination for octokit client called in block
-          #
-          # @yield [octo] Give octokit client with disabled auto pagination
-          # @yieldparam [Octokit::Client, Fbe::FakeOctokit] Octokit client
-          # @return [Object] Last value in block
-          # @example
-          #   issue =
-          #      Fbe.octo.with_disable_auto_paginate do |octo|
-          #        octo.list_issue('zerocracy/fbe', per_page: 1).first
-          #      end
-          def with_disable_auto_paginate # rubocop:disable Layout/EmptyLineBetweenDefs
-            ap = @origin.auto_paginate
-            @origin.auto_paginate = false
-            yield(self) if block_given?
-          ensure
-            @origin.auto_paginate = ap
+          def public_send(...) # rubocop:disable Layout/EmptyLineBetweenDefs, Elegant/GoodMethodName
+            __send__(...)
           end
         end
-      o =
-        intercepted(o) do |e, m, _args, _r|
-          next unless e == :before
-          next if %i[off_quota? print_trace! rate_limit].include?(m)
-          if Fbe::SEARCH_METHODS.include?(m)
-            raise(Fbe::OffQuota, "We are off-quota on the search resource, can't do #{m}()") if
-              o.off_quota?(resource: :search)
-          elsif o.off_quota?
-            raise(Fbe::OffQuota, "We are off-quota (remaining: #{o.rate_limit.remaining}), can't do #{m}()")
-          end
-        end
-      o.instance_eval do
-        def send(...)
-          __send__(...)
-        end
-        def public_send(...) # rubocop:disable Layout/EmptyLineBetweenDefs, Elegant/GoodMethodName
-          __send__(...)
-        end
+        o
       end
-      o
-    end
+  end
 end
 
 # Fake GitHub client for testing purposes.


### PR DESCRIPTION
Wrapped `global[:fb] ||=` (fb.rb), `global[:octo] ||=` (octo.rb), and `global[:github_graph] ||=` (github_graph.rb) in `Fbe::GLOBAL_MUTEX.synchronize` to prevent race conditions when multiple judges initialize these clients concurrently.

Bypasses the need for per-file lazy mutex init (avoids double-checked locking race on the mutex itself).

- Added `Fbe::GLOBAL_MUTEX = Mutex.new` to `lib/fbe.rb`
- All tests pass, RuboCop clean