### PR TITLE
#529 fix stale cached state in Iterate#over on restart

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -308,7 +308,7 @@ class Fbe::Iterate
           if nxt.nil?
             @loog.debug("Next element after ##{before[repo]} not suggested, re-starting from ##{@since}: #{@query}")
             restarted << repo
-            values.delete(repo) if @sorting
+            values.delete(repo)
             @since
           else
             @loog.debug("Next is ##{nxt}, starting from it")


### PR DESCRIPTION
Made `values.delete(repo)` unconditional (previously guarded by `if @sorting`) so cached enumerator state is always cleared on restart for both sorting and non-sorting paths.

All tests pass, RuboCop clean.