### PR TITLE
fix: #538 escape regex metacharacters in Fbe.mask_to_regex

### DIFF
--- a/lib/fbe/unmask_repos.rb
+++ b/lib/fbe/unmask_repos.rb
@@ -24,7 +24,7 @@ require_relative 'over'
 def Fbe.mask_to_regex(mask)
   org, repo = mask.split('/')
   raise(Fbe::Error, "Org '#{org}' can't have an asterisk") if org.include?('*')
-  Regexp.compile("#{org}/#{repo.gsub('*', '.*')}", Regexp::IGNORECASE)
+  Regexp.compile("#{Regexp.escape(org)}/#{Regexp.escape(repo).gsub('\\*', '.*')}", Regexp::IGNORECASE)
 end
 
 # Resolves repository masks to actual GitHub repository names.

--- a/test/fbe/test_unmask_repos.rb
+++ b/test/fbe/test_unmask_repos.rb
@@ -50,6 +50,26 @@ class TestUnmaskRepos < Fbe::Test
     assert_equal(2, list.size)
   end
 
+  def test_mask_to_regex_treats_dot_as_literal
+    re = Fbe.mask_to_regex('zold-io/blog.zold.io')
+    assert_match(re, 'zold-io/blog.zold.io')
+    refute_match(re, 'zold-io/blogXzoldYio')
+  end
+
+  def test_mask_to_regex_escapes_other_metacharacters
+    re = Fbe.mask_to_regex('foo/bar+baz')
+    assert_match(re, 'foo/bar+baz')
+    refute_match(re, 'foo/barbaz')
+    refute_match(re, 'foo/barrrbaz')
+  end
+
+  def test_mask_to_regex_still_expands_wildcard
+    re = Fbe.mask_to_regex('zold-io/blog.zold.*')
+    assert_match(re, 'zold-io/blog.zold.io')
+    assert_match(re, 'zold-io/blog.zold.org')
+    refute_match(re, 'zold-io/blogXzoldYio')
+  end
+
   def test_live_usage
     skip('Run it only manually, since it touches GitHub API')
     opts = Judges::Options.new({ 'repositories' => 'zerocracy/*,-zerocracy/judges-action,zerocracy/datum' })


### PR DESCRIPTION
Fbe.mask_to_regex used to interpolate the mask straight into the pattern and only translate `*`. Every other regex metacharacter (a dot, a plus, parentheses, etc.) survived unchanged and was reinterpreted as an operator at match time. A wildcard like `zold-io/blog.zold.*` therefore matched siblings such as `zold-io/blogXzoldYio`, and a literal exclusion like `-zold-io/blog.zold.io` dropped repositories whose names merely shared that skeleton. Issue #538 lays the failure out file-by-file.

The change routes both halves of the mask through `Regexp.escape` and then turns the escaped literal `\*` back into `.*` so wildcards keep working. Only `lib/fbe/unmask_repos.rb:27` is touched, plus three minitest cases in `test/fbe/test_unmask_repos.rb` covering a literal dot, a non-dot metacharacter (`+`), and the wildcard-still-expands path.

Local checks against ruby 3.3.6 on linux: `bundle exec ruby -Itest test/fbe/test_unmask_repos.rb` runs the seven non-skipped tests with 24 assertions and 0 failures; `rubocop lib/fbe/unmask_repos.rb test/fbe/test_unmask_repos.rb --format simple` reports no offenses. The wider `rake test` shows 10 pre-existing `Fbe::OffQuota` errors in `test/fbe/test_octo.rb` and the middleware suites that also reproduce on a clean `master` checkout in this sandbox, so they are not introduced by this commit; GitHub CI on `master` is currently green, which matches the pre-existing-vs-environment split.

Closes #538
