### PR TITLE
#539: Delete_one guard against fact recreation when value is not in array

### DIFF
--- a/lib/fbe/delete_one.rb
+++ b/lib/fbe/delete_one.rb
@@ -28,8 +28,10 @@ def Fbe.delete_one(fact, prop, value, fb: Fbe.fb, id: '_id')
     before[k] = fact[k]
   end
   return unless before[prop]
-  before[prop] = before[prop] - [value]
-  before.delete(prop) if before[prop].empty?
+  nv = before[prop] - [value]
+  return if nv == before[prop]
+  before[prop] = nv
+  before.delete(prop) if nv.empty?
   fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
     c = fbt.insert

--- a/test/fbe/test_delete_one.rb
+++ b/test/fbe/test_delete_one.rb
@@ -53,4 +53,20 @@ class TestDeleteOne < Fbe::Test
     assert_equal(1, fb.query('(exists foo)').each.to_a.size)
     assert_equal(1, fb.query('(eq foo 42)').each.to_a.size)
   end
+
+  def test_does_not_recreate_fact_when_value_not_present
+    opts = Judges::Options.new(['testing=true'])
+    fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
+    f = fb.insert
+    f.what = 'test'
+    f.foo = 1
+    f.foo = 2
+    f.foo = 3
+    id = f._id
+    Fbe.delete_one(f, 'foo', 99, fb:)
+    r = fb.query('(eq what "test")').each.first
+    assert_equal(1, fb.query('(eq what "test")').each.to_a.size)
+    assert_equal(id, r._id, 'The _id must not change when value is not in the array')
+    assert_equal([1, 2, 3], r['foo'])
+  end
 end


### PR DESCRIPTION
Closes #539.

When `Fbe.delete_one` is called with a value that is not present in the existing array property, the subtraction `before[prop] - [value]` returns the array unchanged. Previously the code still fell through to the `delete!` + `insert` cycle, destroying the fact and recreating it with the same content but a brand-new `_id`.

This is a sibling of #515 but with its own trigger: there the recreate path runs because a real change was requested; here it runs even though the array did not change, silently rewriting the fact identity and dangling any references to the original `_id`.

**Fix:** Early return when the subtraction produces the same array as the original.

**Test:** New `test_does_not_recreate_fact_when_value_not_present` builds a fact through `Fbe.fb` (so the `Pre` hook assigns `_id`), calls `delete_one` with a value not in the array, and asserts the `_id` is unchanged.

All tests pass, RuboCop clean.