### PR TITLE
#529 batch iterate pre-loop into a single factbase query

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -254,19 +254,14 @@ class Fbe::Iterate
       ).map { |n| oct.repo_id_by_name(n) }
     started = Time.now
     restarted = []
-    before =
-      repos.to_h do |repo|
-        [
-          repo,
-          @fb.query(
-            "(agg (and
-              (eq what 'iterate')
-              (eq where 'github')
-              (eq repository #{repo}))
-            (first #{@label}))"
-          ).one&.first || @since
-        ]
-      end
+    markers = {}
+    @fb.query("(and (eq what 'iterate') (eq where 'github'))").each do |f|
+      r = f['repository']&.first
+      next if r.nil? || markers.key?(r)
+      v = f[@label.to_s]&.first
+      markers[r] = v unless v.nil?
+    end
+    before = repos.to_h { |repo| [repo, markers[repo] || @since] }
     starts = before.dup
     values = {}
     loop do # rubocop:disable Metrics/BlockLength


### PR DESCRIPTION
Issue #529 reports an N+1 in `Fbe::Iterate#over`: the iterator calls `fb.query(...).one` once per repository. VasilevNStas analyzed it correctly — the inner loop's `@fb.query(@query).one(@fb, before: before[repo], repository: repo)` at line 305 cannot be batched because every iteration feeds `$before` from the previous block result back into the query. That part stays untouched.

The pre-loop at lines 257-269 is different. Each repo runs a self-contained `(agg (and (eq what 'iterate') (eq where 'github') (eq repository R)) (first @label))` query that has no per-iteration dependency, so |repos| identical-shape queries collapse cleanly into one `(and (eq what 'iterate') (eq where 'github'))` scan that populates a repo-to-marker hash. The `Fbe.if_absent` write path on lines 347-352 keeps at most one iterate fact per `(what, where, repository)` tuple, so taking the first encountered fact per repository matches the prior `.one&.first` semantics, and the `@since` fallback is preserved verbatim.

Verification on the local checkout:
- `bundle exec ruby -Itest test/fbe/test_iterate.rb` — 25 tests, 55 assertions, 0 failures, 0 errors, 0 skips. `test_all_markers_in_one_fact`, `test_all_markers_in_one_exists_fact`, `test_multiple_repositories_with_different_progress`, `test_with_restart`, and `test_persists_marker_facts` all pass.
- `rubocop lib/fbe/iterate.rb --format simple` — no offenses.
- The 10 pre-existing `Fbe::OffQuota` errors in the wider suite (octo, middleware, sqlite) reproduce identically on a clean `master` checkout and are not introduced by this commit.

Closes #529
