### PR TITLE
#542 preserve _id, _time, _version, _job on Fbe.delete recreate path

### DIFF
--- a/lib/fbe/delete.rb
+++ b/lib/fbe/delete.rb
@@ -33,10 +33,16 @@ def Fbe.delete(fact, *props, fb: Fbe.fb, id: '_id')
     next if props.include?(k)
     before[k] = fact[k]
   end
-  before.delete(id)
   fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
     c = fbt.insert
+    f = c
+    while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)
+      iv = f.instance_variable_defined?(:@fact) ? :@fact : :@origin
+      f = f.instance_variable_get(iv)
+    end
+    map = f.instance_variable_get(:@map)
+    %w[_id _time _version _job].each { |k| map.delete(k) if before.key?(k) }
     before.each do |k, vv|
       next unless c[k].nil?
       vv.each do |v|

--- a/test/fbe/test_delete.rb
+++ b/test/fbe/test_delete.rb
@@ -122,4 +122,27 @@ class TestDelete < Fbe::Test
     fact = fb.query('(always)').each.first
     assert_nil(fact['_id'])
   end
+
+  def test_preserves_system_props_on_decorated_fb
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new(job_id: 42)
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    snapshot = { id: target._id, time: target._time, version: target._version, job: target._job }
+    target.bar = 'temp'
+    Fbe.delete(target, 'bar', fb: fbx)
+    after = fbx.query('(eq foo 1)').each.first
+    assert_equal(snapshot[:id], after._id)
+    assert_equal(snapshot[:time], after._time)
+    assert_equal(snapshot[:version], after._version)
+    assert_equal(snapshot[:job], after._job)
+  end
 end


### PR DESCRIPTION
Issue #542 reports that `Fbe.delete` reassigns the four system properties whenever the factbase is decorated by `Fbe.fb`. The destroy-and-recreate cycle in `lib/fbe/delete.rb` deleted `_id` from the snapshot up front, then routed the recreated fact through the `Factbase::Pre` block that assigns `_id`, `_time`, `_version`, and `_job` on insert, and the restoration loop's `next unless c[k].nil?` guard refused to overwrite the Pre-assigned values. Any external reference to the original `_id`, including follower facts and later `(eq _id N)` lookups, was left dangling.

The fix strips the four system properties from the new fact's internal map after `Pre` fires but before the restoration loop runs, so the loop carries the original values forward. `before.delete(id)` is gone, so `_id` survives into the snapshot like the rest. `test_deletes_safely` continues to pass because its single-fact factbase still produces the same `_id` value, while a new `test_preserves_system_props_on_decorated_fb` pins the contract against a two-fact factbase where the Pre arithmetic would otherwise drift.

Verification on this branch: `bundle exec ruby -Ilib -Itest test/fbe/test_delete.rb` reports 10 tests, 21 assertions, 0 failures, 0 errors, 0 skips; `rubocop lib/fbe/delete.rb test/fbe/test_delete.rb` reports 0 offenses. Reverting only the `lib/fbe/delete.rb` change flips the new test to `Expected: 1, Actual: 3`, confirming it catches the bug.

Closes #542