### PR TITLE
docs: #544 align ruby floor in README with gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Read
 [these guidelines](https://www.yegor256.com/2014/04/15/github-guidelines.html).
 Make sure your build is green before you contribute
 your pull request. You will need to have
-[Ruby](https://www.ruby-lang.org/en/) 3.2+ and
+[Ruby](https://www.ruby-lang.org/en/) 3.3+ and
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash


### PR DESCRIPTION
The contribution guide on README.md:55 advertises Ruby 3.2+ as the floor for running `bundle update` and `bundle exec rake`. The gemspec at fbe.gemspec:11 declares `required_ruby_version = '>=3.3'`, and the CI matrix in .github/workflows/rake.yml only schedules ruby 3.3, so the floor that actually runs is 3.3. A contributor who provisions 3.2 to match the README cannot reach the test suite — bundler aborts at the gemspec gate before the very first build command in the guide.

This one-line change replaces `Ruby 3.2+` with `Ruby 3.3+` so the documented prerequisite matches the binding contract that ships to RubyGems consumers and the matrix on which CI is actually green. The reverse direction (relaxing the gemspec) is not safe because the gemspec floor is what consumers see.

Closes #544

Test plan: ran `bundle exec rake test` locally against the change — README is documentation only, no code paths touched. The 10 pre-existing `Fbe::OffQuota` errors observed in the local run are environment-related (no GitHub API quota in the sandbox) and unrelated to the diff.