### PR TITLE
docs: align README Ruby prerequisite with gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Read
 [these guidelines](https://www.yegor256.com/2014/04/15/github-guidelines.html).
 Make sure your build is green before you contribute
 your pull request. You will need to have
-[Ruby](https://www.ruby-lang.org/en/) 3.2+ and
+[Ruby](https://www.ruby-lang.org/en/) 3.3+ and
 [Bundler](https://bundler.io/) installed. Then:
 
 ```bash


### PR DESCRIPTION
Closes #544

## Summary
- update the README prerequisite from Ruby 3.2+ to Ruby 3.3+
- align the contributor instructions with the gemspec and CI floor

## Validation
- docs-only change