### PR TITLE
#552: Patch core rate-limit remaining

### DIFF
--- a/lib/fbe/middleware/rate_limit.rb
+++ b/lib/fbe/middleware/rate_limit.rb
@@ -117,6 +117,7 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
         return original
       end
     body['rate']['remaining'] = @remaining if body['rate']
+    body.dig('resources', 'core')&.[]=('remaining', @remaining)
     body.dig('resources', 'search')&.[]=('remaining', @searchleft)
     stringed ? body.to_json : body
   end

--- a/test/fbe/middleware/test_rate_limit.rb
+++ b/test/fbe/middleware/test_rate_limit.rb
@@ -156,6 +156,7 @@ class RateLimitTest < Fbe::Test
     response = conn.get('/rate_limit')
     assert_equal(30, response.body['resources']['search']['remaining'])
     assert_equal(4998, response.body['rate']['remaining'])
+    assert_equal(4998, response.body['resources']['core']['remaining'])
   end
 
   def test_search_remaining_survives_repeated_search_calls_within_cache_window


### PR DESCRIPTION
/claim #552

Closes #552.

Summary:
- Update cached `/rate_limit` responses so `resources.core.remaining` mirrors the decremented core quota.
- Add a regression assertion proving non-search requests update both `rate.remaining` and `resources.core.remaining` while leaving `resources.search.remaining` unchanged.

Validation:
- `bundle check`
- `ruby -c lib/fbe/middleware/rate_limit.rb`
- `ruby -c test/fbe/middleware/test_rate_limit.rb`
- `git diff --check`
- `bundle exec ruby -Itest test/fbe/middleware/test_rate_limit.rb -- --no-cov` (`16` tests, `33` assertions, `0` failures, `0` errors, `0` skips)
- `bundle exec rake test` (`338` tests, `921` assertions, `0` failures, `0` errors, `9` skips)
- `bundle exec rubocop` (`66` files inspected, no offenses detected)
- `bundle exec rake` (completed `test`, `rubocop`, `picks`, and `yard` successfully)

No secrets, credentials, wallet, KYC/tax, signing, payout, or off-ramp actions used.