### PR TITLE
#551: Keep fact replacement atomic

### DIFF
--- a/lib/fbe/delete.rb
+++ b/lib/fbe/delete.rb
@@ -33,8 +33,8 @@ def Fbe.delete(fact, *props, fb: Fbe.fb, id: '_id')
     next if props.include?(k)
     before[k] = fact[k]
   end
-  fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
+    fbt.query("(eq #{id} #{i})").delete!
     c = fbt.insert
     f = c
     while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)

--- a/lib/fbe/delete_one.rb
+++ b/lib/fbe/delete_one.rb
@@ -32,8 +32,8 @@ def Fbe.delete_one(fact, prop, value, fb: Fbe.fb, id: '_id')
   return if nv == before[prop]
   before[prop] = nv
   before.delete(prop) if nv.empty?
-  fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
+    fbt.query("(eq #{id} #{i})").delete!
     c = fbt.insert
     before.each do |k, vv|
       next unless c[k].nil?

--- a/lib/fbe/overwrite.rb
+++ b/lib/fbe/overwrite.rb
@@ -65,8 +65,8 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
     end
     id = fact[fid]&.first
     raise(Fbe::Error, "There is no #{fid} in the fact, cannot use Fbe.overwrite") if id.nil?
-    raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
     fb.txn do |fbt|
+      raise(Fbe::Error, "No facts by #{fid} = #{id}") if fbt.query("(eq #{fid} #{id})").delete!.zero?
       n = fbt.insert
       before.each do |k, vv|
         next unless n[k].nil?
@@ -94,8 +94,8 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
   end
   id = fact[fid]&.first
   raise(Fbe::Error, "There is no #{fid} in the fact, cannot use Fbe.overwrite") if id.nil?
-  raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
   fb.txn do |fbt|
+    raise(Fbe::Error, "No facts by #{fid} = #{id}") if fbt.query("(eq #{fid} #{id})").delete!.zero?
     n = fbt.insert
     before[property.to_s] = values
     before.each do |k, vv|

--- a/test/fbe/test_delete.rb
+++ b/test/fbe/test_delete.rb
@@ -113,6 +113,24 @@ class TestDelete < Fbe::Test
     assert_nil(after['foo'])
   end
 
+  def test_keeps_original_fact_when_reinsert_fails
+    reject = false
+    fb =
+      Factbase::Pre.new(Factbase.new) do |_f, _fbt|
+        raise(RuntimeError, 'insert failed') if reject
+      end
+    f = fb.insert
+    f._id = 44
+    f.foo = 42
+    f.bar = 'keep'
+    reject = true
+    assert_raises(RuntimeError) { Fbe.delete(f, 'foo', fb:) }
+    after = fb.query('(eq _id 44)').each.to_a
+    assert_equal(1, after.size)
+    assert_equal([42], after.first['foo'])
+    assert_equal(['keep'], after.first['bar'])
+  end
+
   def test_deletes_when_duplicate_id
     fb = Factbase.new
     f = fb.insert

--- a/test/fbe/test_delete_one.rb
+++ b/test/fbe/test_delete_one.rb
@@ -69,4 +69,23 @@ class TestDeleteOne < Fbe::Test
     assert_equal(id, r._id, 'The _id must not change when value is not in the array')
     assert_equal([1, 2, 3], r['foo'])
   end
+
+  def test_keeps_original_fact_when_reinsert_fails
+    reject = false
+    fb =
+      Factbase::Pre.new(Factbase.new) do |_f, _fbt|
+        raise(RuntimeError, 'insert failed') if reject
+      end
+    f = fb.insert
+    f._id = 555
+    f.foo = 42
+    f.foo = 'hello'
+    f.bar = 'keep'
+    reject = true
+    assert_raises(RuntimeError) { Fbe.delete_one(f, 'foo', 42, fb:) }
+    after = fb.query('(eq _id 555)').each.to_a
+    assert_equal(1, after.size)
+    assert_equal([42, 'hello'], after.first['foo'])
+    assert_equal(['keep'], after.first['bar'])
+  end
 end

--- a/test/fbe/test_overwrite.rb
+++ b/test/fbe/test_overwrite.rb
@@ -122,6 +122,24 @@ class TestOverwrite < Fbe::Test
     assert_equal('bar', after.foo)
   end
 
+  def test_keeps_original_fact_when_scalar_reinsert_fails
+    reject = false
+    fb =
+      Factbase::Pre.new(Factbase.new) do |_f, _fbt|
+        raise(RuntimeError, 'insert failed') if reject
+      end
+    f = fb.insert
+    f._id = 1
+    f.foo = 42
+    f.bar = 'keep'
+    reject = true
+    assert_raises(RuntimeError) { Fbe.overwrite(f, 'foo', 55, fb:) }
+    after = fb.query('(eq _id 1)').each.to_a
+    assert_equal(1, after.size)
+    assert_equal([42], after.first['foo'])
+    assert_equal(['keep'], after.first['bar'])
+  end
+
   def test_overwrite_with_hash_single_property
     fb = Factbase.new
     f = fb.insert
@@ -234,6 +252,25 @@ class TestOverwrite < Fbe::Test
     assert_equal(100, result['foo'].first)
     assert_equal('old', result['bar'].first)
     assert_equal('new_property', result['baz'].first)
+  end
+
+  def test_keeps_original_fact_when_hash_reinsert_fails
+    reject = false
+    fb =
+      Factbase::Pre.new(Factbase.new) do |_f, _fbt|
+        raise(RuntimeError, 'insert failed') if reject
+      end
+    f = fb.insert
+    f._id = 1
+    f.foo = 42
+    f.bar = 'keep'
+    reject = true
+    assert_raises(RuntimeError) { Fbe.overwrite(f, { foo: 55, baz: 'new' }, fb:) }
+    after = fb.query('(eq _id 1)').each.to_a
+    assert_equal(1, after.size)
+    assert_equal([42], after.first['foo'])
+    assert_equal(['keep'], after.first['bar'])
+    assert_nil(after.first['baz'])
   end
 
   def test_overwrite_with_hash_mixed_key_types


### PR DESCRIPTION
/claim #551

Closes #551.

## Summary
- Move the delete step for `Fbe.overwrite`, `Fbe.delete`, and `Fbe.delete_one` inside the same `fb.txn` block as the replacement insert.
- Add regression tests proving the original fact remains when the replacement insert raises.

## Validation
- `bundle check`
- `bundle exec ruby -Itest test/fbe/test_overwrite.rb -- --no-cov`
- `bundle exec ruby -Itest test/fbe/test_delete.rb -- --no-cov`
- `bundle exec ruby -Itest test/fbe/test_delete_one.rb -- --no-cov`
- `git diff --check`
- `bundle exec rubocop lib/fbe/overwrite.rb lib/fbe/delete.rb lib/fbe/delete_one.rb test/fbe/test_overwrite.rb test/fbe/test_delete.rb test/fbe/test_delete_one.rb`
- `bundle exec rake test`
- `bundle exec rubocop`
- `bundle exec rake`

No secrets or live-user data used; validation was local and within the repo scope.