### PR TITLE
#546: Guard formatter JSON error parsing

### DIFF
--- a/lib/fbe/middleware/formatter.rb
+++ b/lib/fbe/middleware/formatter.rb
@@ -69,16 +69,17 @@ class Fbe::Middleware::Formatter < Faraday::Logging::Formatter
   def response(http) # rubocop:disable Metrics/AbcSize
     return if http.status < 400
     if http.status == 403 && http.response_headers['content-type']&.start_with?('application/json')
-      warn(
-        [
-          "#{@req.method.upcase} #{apply_filters(@req.url.to_s)}",
-          '->',
-          http.status,
-          '/',
-          JSON.parse(http.response_body)['message']
-        ].join(' ')
-      )
-      return
+      msg =
+        begin
+          parsed = JSON.parse(http.response_body)
+          parsed['message'] if parsed.is_a?(Hash)
+        rescue JSON::ParserError, TypeError
+          nil
+        end
+      unless msg.nil?
+        warn(["#{@req.method.upcase} #{apply_filters(@req.url.to_s)}", '->', http.status, '/', msg].join(' '))
+        return
+      end
     end
     if http.status >= 500 && http.response_headers['content-type']&.start_with?('text')
       error(

--- a/test/fbe/middleware/test_formatter.rb
+++ b/test/fbe/middleware/test_formatter.rb
@@ -60,6 +60,33 @@ class LoggingFormatterTest < Fbe::Test
     end
   end
 
+  def test_limit_response_with_empty_json_body
+    log_it(status: 403, response_body: '') do |loog|
+      str = loog.to_s
+      refute_empty(str)
+      assert_match(%r{http://example.com}, str)
+      assert_match(%r{HTTP/1.1 403}, str)
+    end
+  end
+
+  def test_limit_response_with_json_body_without_message
+    log_it(status: 403, response_body: '{}') do |loog|
+      str = loog.to_s
+      refute_empty(str)
+      assert_match(%r{HTTP/1.1 403}, str)
+      assert_match(/\{\}/, str)
+    end
+  end
+
+  def test_limit_response_with_malformed_json_body
+    log_it(status: 403, response_body: '<html>denied</html>') do |loog|
+      str = loog.to_s
+      refute_empty(str)
+      assert_match(%r{HTTP/1.1 403}, str)
+      assert_match(%r{<html>denied</html>}, str)
+    end
+  end
+
   def test_filters_basic_auth_credentials_from_log
     log_it(status: 500, request_headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' }) do |loog|
       str = loog.to_s


### PR DESCRIPTION
/claim #546

Closes #546

Summary:
- Guard 403 JSON error-message extraction against empty, malformed, non-object, or message-less bodies.
- Fall through to the existing generic error logging path when no safe JSON message is available.
- Add formatter regressions for empty JSON body, JSON without message, and malformed body with application/json content-type.

Validation:
- bundle check: passed
- ruby -c lib/fbe/middleware/formatter.rb: Syntax OK
- ruby -c test/fbe/middleware/test_formatter.rb: Syntax OK
- bundle exec ruby -Itest test/fbe/middleware/test_formatter.rb -- --no-cov: 11 tests, 72 assertions, 0 failures, 0 errors, 0 skips
- bundle exec rubocop lib/fbe/middleware/formatter.rb test/fbe/middleware/test_formatter.rb: 2 files inspected, no offenses
- git diff --check: passed
- bundle exec rake test: 341 tests, 938 assertions, 0 failures, 0 errors, 9 skips
- bundle exec rubocop: 66 files inspected, no offenses
- bundle exec rake: passed test, rubocop, picks, and yard

No secrets or credentials included.