### PR TITLE
#515: preserve system properties on overwrite/delete_one recreate paths

### DIFF
--- a/lib/fbe/delete_one.rb
+++ b/lib/fbe/delete_one.rb
@@ -35,6 +35,13 @@ def Fbe.delete_one(fact, prop, value, fb: Fbe.fb, id: '_id')
   fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
     c = fbt.insert
+    f = c
+    while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)
+      iv = f.instance_variable_defined?(:@fact) ? :@fact : :@origin
+      f = f.instance_variable_get(iv)
+    end
+    map = f.instance_variable_get(:@map)
+    %w[_id _time _version _job].each { |k| map.delete(k) if before.key?(k) }
     before.each do |k, vv|
       next unless c[k].nil?
       vv.each do |v|

--- a/lib/fbe/overwrite.rb
+++ b/lib/fbe/overwrite.rb
@@ -68,6 +68,13 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
     raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
     fb.txn do |fbt|
       n = fbt.insert
+      f = n
+      while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)
+        iv = f.instance_variable_defined?(:@fact) ? :@fact : :@origin
+        f = f.instance_variable_get(iv)
+      end
+      map = f.instance_variable_get(:@map)
+      %w[_id _time _version _job].each { |k| map.delete(k) if before.key?(k) }
       before.each do |k, vv|
         next unless n[k].nil?
         vv.each do |v|
@@ -97,6 +104,13 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
   raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
   fb.txn do |fbt|
     n = fbt.insert
+    f = n
+    while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)
+      iv = f.instance_variable_defined?(:@fact) ? :@fact : :@origin
+      f = f.instance_variable_get(iv)
+    end
+    map = f.instance_variable_get(:@map)
+    %w[_id _time _version _job].each { |k| map.delete(k) if before.key?(k) }
     before[property.to_s] = values
     before.each do |k, vv|
       next unless n[k].nil?

--- a/test/fbe/test_delete_one.rb
+++ b/test/fbe/test_delete_one.rb
@@ -69,4 +69,29 @@ class TestDeleteOne < Fbe::Test
     assert_equal(id, r._id, 'The _id must not change when value is not in the array')
     assert_equal([1, 2, 3], r['foo'])
   end
+
+  def test_preserves_system_props_on_decorated_fb
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new(job_id: 42)
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    target.bar = 11
+    target.bar = 22
+    snapshot = { id: target._id, time: target._time, version: target._version, job: target._job }
+    Fbe.delete_one(target, 'bar', 11, fb: fbx)
+    after = fbx.query('(eq foo 1)').each.first
+    assert_equal(snapshot[:id], after._id)
+    assert_equal(snapshot[:time], after._time)
+    assert_equal(snapshot[:version], after._version)
+    assert_equal(snapshot[:job], after._job)
+    assert_equal([22], after['bar'])
+  end
 end

--- a/test/fbe/test_overwrite.rb
+++ b/test/fbe/test_overwrite.rb
@@ -384,4 +384,53 @@ class TestOverwrite < Fbe::Test
     assert_equal('Привет мир', result['russian'].first)
     assert_equal('こんにちは世界', result['japanese'].first)
   end
+
+  def test_preserves_system_props_on_decorated_fb_scalar
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new(job_id: 42)
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    target.bar = 'old'
+    snapshot = { id: target._id, time: target._time, version: target._version, job: target._job }
+    Fbe.overwrite(target, 'bar', 'new', fb: fbx)
+    after = fbx.query('(eq foo 1)').each.first
+    assert_equal(snapshot[:id], after._id)
+    assert_equal(snapshot[:time], after._time)
+    assert_equal(snapshot[:version], after._version)
+    assert_equal(snapshot[:job], after._job)
+    assert_equal(['new'], after['bar'])
+  end
+
+  def test_preserves_system_props_on_decorated_fb_hash_overwrites_existing
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '3' } }
+    )
+    fb = Factbase.new
+    global = {}
+    options = Judges::Options.new(job_id: 42)
+    loog = Loog::NULL
+    fbx = Fbe.fb(fb:, global:, options:, loog:)
+    fbx.insert.then { |f| f.foo = 1 }
+    fbx.insert.then { |f| f.foo = 2 }
+    target = fbx.query('(eq foo 1)').each.first
+    target.bar = 'old'
+    snapshot = { id: target._id, time: target._time, version: target._version, job: target._job }
+    Fbe.overwrite(target, { bar: 'new', baz: 'added' }, fb: fbx)
+    after = fbx.query('(eq foo 1)').each.first
+    assert_equal(snapshot[:id], after._id)
+    assert_equal(snapshot[:time], after._time)
+    assert_equal(snapshot[:version], after._version)
+    assert_equal(snapshot[:job], after._job)
+    assert_equal(['new'], after['bar'])
+    assert_equal(['added'], after['baz'])
+  end
 end


### PR DESCRIPTION
Closes #515

The hash and scalar recreate paths in `lib/fbe/overwrite.rb` and the recreate path in `lib/fbe/delete_one.rb` already preserved every user-defined property, but the `Factbase::Pre` hook in `lib/fbe/fb.rb:43-49` reassigned `_id`, `_time`, `_version`, and `_job` on every `fbt.insert`, and the subsequent restore loop's `next unless n[k].nil?` guard then skipped putting the originals back. This patch applies the same drill-through pattern that `Fbe.delete` already uses (introduced for #542 in #545): walk the `@fact`/`@origin` decorator chain to the inner `Factbase::Fact`, delete the system keys from its `@map` whenever they were captured into `before`, and let the existing loop restore them.

The visible effect is that a fact recreated via `Fbe.overwrite` (scalar or hash form, overwrites-existing branch) or `Fbe.delete_one` against an `Fbe.fb`-decorated factbase now keeps the same `_id` (and `_time`, `_version`, `_job`), so external references to the original `_id` no longer dangle. Three regression tests in `test/fbe/test_overwrite.rb` and `test/fbe/test_delete_one.rb` build the factbase through `Fbe.fb`, snapshot the system properties before the call, and assert they equal the post-call values; they followed the model of `test_preserves_system_props_on_decorated_fb` already in `test/fbe/test_delete.rb`.

Checks run locally on ruby 3.3.6:
- `bundle exec ruby -Ilib -Itest test/fbe/test_overwrite.rb` -> 31 tests, 74 assertions, 0 failures, 0 errors, 0 skips
- `bundle exec ruby -Ilib -Itest test/fbe/test_delete_one.rb` -> 5 tests, 19 assertions, 0 failures, 0 errors, 0 skips
- `ruby -e 'require "rubocop"; RuboCop::CLI.new.run(["lib/fbe/delete_one.rb", "lib/fbe/overwrite.rb", "test/fbe/test_delete_one.rb", "test/fbe/test_overwrite.rb"])'` -> 4 files inspected, no offenses
- `git diff --check origin/master...HEAD` -> clean