### PR TITLE
#558 widen sqlite_store rescue to cover JSON::ParserError

### DIFF
--- a/lib/fbe/middleware/sqlite_store.rb
+++ b/lib/fbe/middleware/sqlite_store.rb
@@ -86,8 +86,8 @@ class Fbe::Middleware::SqliteStore
     return unless value
     begin
       JSON.parse(Zlib::Inflate.inflate(value))
-    rescue Zlib::Error => e
-      @loog.info("Failed to decompress cached value for key: #{key}, error: #{e.message}, the key will be deleted")
+    rescue Zlib::Error, JSON::ParserError, TypeError => e
+      @loog.info("Failed to decode cached value for key: #{key}, error: #{e.message}, the key will be deleted")
       delete(key)
     end
   end

--- a/test/fbe/middleware/test_sqlite_store.rb
+++ b/test/fbe/middleware/test_sqlite_store.rb
@@ -238,6 +238,21 @@ class SqliteStoreTest < Fbe::Test
     end
   end
 
+  def test_non_json_deflated_payload_does_not_raise
+    with_tmpfile('c.db') do |f|
+      Fbe::Middleware::SqliteStore.new(f, '0.0.1', loog: fake_loog).then do |store|
+        store.__send__(:perform) do |t|
+          t.execute(
+            'INSERT INTO cache(key, value, touched_at, created_at) VALUES(?1, ?2, ?3, ?3);',
+            ['poisoned', Zlib::Deflate.deflate('not a json document'), Time.now.utc.iso8601]
+          )
+        end
+        assert_nil(store.read('poisoned'))
+        assert_predicate(store.all.count, :zero?)
+      end
+    end
+  end
+
   def test_upgrade_sqlite_schema_for_add_created_at_column
     with_tmpfile('a.db') do |f|
       SQLite3::Database.new(f).tap do |d|


### PR DESCRIPTION
`Fbe::Middleware::SqliteStore#read` previously rescued only `Zlib::Error`, so a deflate stream that decoded into a non-JSON payload — partial writes, SQLite corruption recovery, leftover rows from older serializations — escaped as `JSON::ParserError` from `read` and crashed `Faraday::HttpCache` on every subsequent lookup for that key. The poisoned row stayed in the database because the existing `delete(key)` branch only ran on a Zlib failure, so until something else evicted the key the middleware was wedged on it.

The rescue is widened to also catch `JSON::ParserError` and `TypeError`, and the log line is renamed from `Failed to decompress` to `Failed to decode` to cover both branches. `delete(key)` still runs, so the next request rebuilds the entry from the network.

A regression test in `test/fbe/middleware/test_sqlite_store.rb` writes a valid deflate stream of a non-JSON payload directly through the store's SQLite handle and asserts that `read(key)` returns `nil` and that `all` reports an empty cache. Ran `bundle exec ruby -Ilib -Itest test/fbe/middleware/test_sqlite_store.rb` locally — 24 tests pass — and `bundle exec rubocop` is clean on both touched files.

Closes #558

---
_Generated by [Claude Code](https://claude.ai/code)_