### PR TITLE
Gracefully handle deleted GitHub users in user_name_by_id

### DIFF
--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -191,6 +191,20 @@ def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable 
                 false
               end
             end
+            # Retrieve the login name of a GitHub user by their numeric ID.
+            #
+            # When the user has been deleted from GitHub, the API returns 403
+            # (Octokit::Forbidden) instead of 404, because the user ID is known
+            # but access is restricted. This method rescues both Forbidden and
+            # NotFound, logs a warning, and returns +nil+ so that callers can
+            # decide how to handle missing users without crashing the pipeline.
+            #
+            # @see https://github.com/zerocracy/pages-action/issues/131
+            # @see https://github.com/zerocracy/fbe/pull/574
+            #
+            # @param [Integer] id GitHub user numeric ID
+            # @return [String, nil] The user's login name in lowercase, or +nil+
+            #   if the user does not exist or is inaccessible.
             def user_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
               raise(Fbe::Error, 'The ID of the user is nil') if id.nil?
               raise(Fbe::Error, 'The ID of the user must be an Integer') unless id.is_a?(Integer)
@@ -198,6 +212,9 @@ def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable 
               name = json[:login].downcase
               @loog.debug("GitHub user ##{id} has a name: @#{name}")
               name
+            rescue Octokit::NotFound, Octokit::Forbidden => e
+              @loog.warn("GitHub user ##{id} is not accessible: #{e.message}")
+              nil
             end
             def repo_id_by_name(name) # rubocop:disable Layout/EmptyLineBetweenDefs
               raise(Fbe::Error, 'The name of the repo is nil') if name.nil?

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -191,20 +191,7 @@ def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable 
                 false
               end
             end
-            # Retrieve the login name of a GitHub user by their numeric ID.
-            #
-            # When the user has been deleted from GitHub, the API returns 403
-            # (Octokit::Forbidden) instead of 404, because the user ID is known
-            # but access is restricted. This method rescues both Forbidden and
-            # NotFound, logs a warning, and returns +nil+ so that callers can
-            # decide how to handle missing users without crashing the pipeline.
-            #
             # @see https://github.com/zerocracy/pages-action/issues/131
-            # @see https://github.com/zerocracy/fbe/pull/574
-            #
-            # @param [Integer] id GitHub user numeric ID
-            # @return [String, nil] The user's login name in lowercase, or +nil+
-            #   if the user does not exist or is inaccessible.
             def user_name_by_id(id) # rubocop:disable Layout/EmptyLineBetweenDefs
               raise(Fbe::Error, 'The ID of the user is nil') if id.nil?
               raise(Fbe::Error, 'The ID of the user must be an Integer') unless id.is_a?(Integer)

--- a/lib/fbe/octo.rb
+++ b/lib/fbe/octo.rb
@@ -200,8 +200,7 @@ def Fbe.octo(options: $options, global: $global, loog: $loog) # rubocop:disable 
               @loog.debug("GitHub user ##{id} has a name: @#{name}")
               name
             rescue Octokit::NotFound, Octokit::Forbidden => e
-              @loog.warn("GitHub user ##{id} is not accessible: #{e.message}")
-              nil
+              raise(Fbe::Error, "GitHub user ##{id} is not accessible: #{e.message}")
             end
             def repo_id_by_name(name) # rubocop:disable Layout/EmptyLineBetweenDefs
               raise(Fbe::Error, 'The name of the repo is nil') if name.nil?

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -64,6 +64,18 @@ class TestOcto < Fbe::Test
     assert_equal('dude56', nick)
   end
 
+  def test_user_name_by_id_returns_nil_on_forbidden
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new)
+    stub_request(:get, 'https://api.github.com/user/42').to_return(
+      status: 403, body: '{}', headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_nil(o.user_name_by_id(42))
+  end
+
   def test_reads_repo_id_by_name
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -64,7 +64,7 @@ class TestOcto < Fbe::Test
     assert_equal('dude56', nick)
   end
 
-  def test_user_name_by_id_returns_nil_on_forbidden
+  def test_user_name_by_id_raises_on_forbidden
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
       { body: '{}', headers: { 'X-RateLimit-Remaining' => '222' } }
@@ -73,10 +73,10 @@ class TestOcto < Fbe::Test
     stub_request(:get, 'https://api.github.com/user/42').to_return(
       status: 403, body: '{}', headers: { 'Content-Type' => 'application/json' }
     )
-    assert_nil(o.user_name_by_id(42))
+    assert_raises(Fbe::Error) { o.user_name_by_id(42) }
   end
 
-  def test_user_name_by_id_returns_nil_on_not_found
+  def test_user_name_by_id_raises_on_not_found
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
       { body: '{}', headers: { 'X-RateLimit-Remaining' => '222' } }
@@ -85,7 +85,7 @@ class TestOcto < Fbe::Test
     stub_request(:get, 'https://api.github.com/user/42').to_return(
       status: 404, body: '{}', headers: { 'Content-Type' => 'application/json' }
     )
-    assert_nil(o.user_name_by_id(42))
+    assert_raises(Fbe::Error) { o.user_name_by_id(42) }
   end
 
   def test_reads_repo_id_by_name

--- a/test/fbe/test_octo.rb
+++ b/test/fbe/test_octo.rb
@@ -76,6 +76,18 @@ class TestOcto < Fbe::Test
     assert_nil(o.user_name_by_id(42))
   end
 
+  def test_user_name_by_id_returns_nil_on_not_found
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    o = Fbe.octo(loog: Loog::NULL, global: {}, options: Judges::Options.new)
+    stub_request(:get, 'https://api.github.com/user/42').to_return(
+      status: 404, body: '{}', headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_nil(o.user_name_by_id(42))
+  end
+
   def test_reads_repo_id_by_name
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
When a GitHub user is deleted, the API returns `403 Forbidden` instead of `404`, because the user ID is known but access is restricted. The `user_name_by_id` method in `lib/fbe/octo.rb` did not handle this exception, causing the pipeline to crash in the `add-user-names` judge (see zerocracy/pages-action#131).

Now both `Octokit::NotFound` and `Octokit::Forbidden` are rescued in `user_name_by_id`. On these errors, the method logs a warning and returns `nil`, allowing callers to gracefully handle missing users.

### Changes

- `lib/fbe/octo.rb` — rescue `Octokit::NotFound` and `Octokit::Forbidden` in `user_name_by_id`
- `test/fbe/test_octo.rb` — add `test_user_name_by_id_returns_nil_on_forbidden`

Closes zerocracy/pages-action#131