### PR TITLE
Persist exhausted-cursor reset so Fbe::Iterate wraps around

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -355,7 +355,7 @@ class Fbe::Iterate
        defined?(before) && !before.nil? &&
        defined?(starts) && !starts.nil?
       repos.each do |repo|
-        next if before[repo] == starts[repo] || before[repo] == @since
+        next if before[repo] == starts[repo]
         f =
           Fbe.if_absent(fb: @fb, always: true) do |n|
             n.what = 'iterate'

--- a/test/fbe/test_iterate.rb
+++ b/test/fbe/test_iterate.rb
@@ -228,6 +228,25 @@ class TestIterate < Fbe::Test
     assert_equal(15, markers.first.marker_test)
   end
 
+  def test_persists_restart_to_since_across_runs
+    opts = Judges::Options.new(['repositories=foo/bar', 'testing=true'])
+    fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
+    fb.insert.then do |f|
+      f.what = 'iterate'
+      f.where = 'github'
+      f.repository = 680
+      f.wrap_test = 10
+    end
+    fb.insert.num = 5
+    Fbe.iterate(fb:, loog: Loog::NULL, global: {}, options: opts, epoch: Time.now, kickoff: Time.now) do
+      as('wrap_test')
+      by('(agg (gt num $before) (min num))')
+      repeats(10)
+      over { |_, nxt| nxt }
+    end
+    assert_equal(0, fb.query("(eq what 'iterate')").each.to_a.first.wrap_test)
+  end
+
   def test_multiple_repositories_with_different_progress
     opts = Judges::Options.new(['repositories=foo/bar,foo/baz', 'testing=true'])
     fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
@@ -403,7 +422,7 @@ class TestIterate < Fbe::Test
       end
     end
     assert_equal(9, fb.query('(and (eq what "judge") (exists prop2))').each.to_a.size)
-    assert_equal(3, fb.query('(eq what "iterate")').each.to_a.first.marker)
+    assert_equal(0, fb.query('(eq what "iterate")').each.to_a.first.marker)
     Fbe.iterate(fb:, loog: Loog::NULL, options: opts, global:, epoch: Time.now, kickoff: Time.now) do
       as('marker')
       sort_by('issue')
@@ -429,7 +448,7 @@ class TestIterate < Fbe::Test
       end
     end
     assert_equal(5, fb.query('(and (eq what "judge") (exists prop3))').each.to_a.size)
-    assert_equal(12, fb.query('(eq what "iterate")').each.to_a.first.marker)
+    assert_equal(10, fb.query('(eq what "iterate")').each.to_a.first.marker)
   end
 
   def test_custom_since


### PR DESCRIPTION
`Fbe::Iterate#over` is meant to make rounds: once a repository's candidate list is exhausted, the cursor resets to `since` and the next run re-scans from the beginning. That reset never survived a run. The `ensure` block declined to write the marker whenever it equalled `since`, so the following run reloaded the stale high-water value and the cursor only ever climbed.

The effect was that any item becoming eligible after the cursor had passed it was orphaned forever. A pull request seen while still open advances the cursor past its number; if it merges later it sits below the cursor and is never re-examined, so `pull-was-merged` never fires and the work goes unrewarded.

The fix drops the `before[repo] == @since` guard so a genuine restart is persisted, while the `before[repo] == starts[repo]` guard still suppresses spurious writes when a repository made no progress. A new test locks in the wrap-around, and `test_sort_by_configuration` was updated to reflect the corrected marker values now that an exhausted repo rewinds to `since`.

Closes #593