### PR TITLE
fix: #595 honor (as ...) rewrite when following properties in Conclude#fill

### DIFF
--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -231,6 +231,13 @@ class Fbe::Conclude
   # calls the provided block for custom processing, and sets metadata
   # on the new fact.
   #
+  # A property that is absent on the previous fact is skipped (its "[]"
+  # accessor returns nil). Factbase's "(as new old)" rewrite is only visible
+  # through method access (prev.new), while "[]" returns the raw stored value
+  # (see #595); when such a rewrite is in effect the method accessor returns
+  # the rewritten value, so we honor it. All values are still copied for
+  # genuinely multi-valued properties (see #520).
+  #
   # @param [Factbase::Fact] fact The fact to populate
   # @param [Factbase::Fact] prev The previous fact to copy from
   # @yield [Factbase::Fact, Factbase::Fact] New fact and the previous fact
@@ -248,7 +255,12 @@ class Fbe::Conclude
   #   end
   def fill(fact, prev)
     @follows.each do |follow|
-      prev[follow.to_s].each do |v|
+      key = follow.to_s
+      values = prev[key]
+      next if values.nil?
+      rewritten = prev.public_send(follow)
+      values = [rewritten] unless values.first == rewritten
+      values.each do |v|
         fact.public_send(:"#{follow}=", v)
       end
     end

--- a/test/fbe/test_conclude.rb
+++ b/test/fbe/test_conclude.rb
@@ -205,6 +205,50 @@ class TestConclude < Fbe::Test
     assert_equal(%w[a b c], n['tags'])
   end
 
+  def test_follow_honors_as_rewrite
+    $fb = Factbase.new
+    $global = {}
+    $epoch = Time.now
+    $loog = Loog::NULL
+    $options = Judges::Options.new
+    f = $fb.insert
+    f.foo = 1
+    f.who = 777
+    f.assignee = 4536
+    Fbe.conclude(judge: 'judge-follow') do
+      quota_unaware
+      on('(and (exists foo) (as who assignee))')
+      follow('who')
+      draw do |n, _prev|
+        n.processed = 'yes'
+        'Some long description that satisfies the twenty five chars minimum.'
+      end
+    end
+    n = $fb.query('(eq processed "yes")').each.to_a[0]
+    assert_equal([4536], n['who'])
+  end
+
+  def test_follow_skips_missing_property
+    $fb = Factbase.new
+    $global = {}
+    $epoch = Time.now
+    $loog = Loog::NULL
+    $options = Judges::Options.new
+    f = $fb.insert
+    f.foo = 1
+    Fbe.conclude(judge: 'judge-follow') do
+      quota_unaware
+      on('(exists foo)')
+      follow('absent')
+      draw do |n, _prev|
+        n.processed = 'yes'
+        'Some long description that satisfies the twenty five chars minimum.'
+      end
+    end
+    n = $fb.query('(eq processed "yes")').each.to_a[0]
+    assert_nil(n['absent'])
+  end
+
   def test_follow_raises_on_second_call
     $fb = Factbase.new
     $global = {}


### PR DESCRIPTION
Fixes #595.

## Problem

`Fbe::Conclude#fill` copied each followed property with `prev[follow.to_s]`. Factbase applies the `(as new old)` term rewrite only on **method access** (`prev.who`), not on `[]`, which returns the raw stored value. So following an `as`-renamed property copied the wrong value.

Minimal repro: for `(and (eq what 'x') (as who assignee))` where the fact has `who=777` and `assignee=4536`, `prev.who` returns `4536` but `prev['who']` returns `[777]`. `fill` was writing `777` into the concluded fact, silently corrupting every judge that follows an `as`-rewritten property (e.g. `bug-was-resolved`, `code-was-contributed`, `code-was-reviewed`).

The prior switch to `[]` (#520) was made to stop truncating multi-valued follows (#509), but `[]` bypasses `(as …)`. Neither accessor is correct alone.

## Fix

In `fill`, for each followed property:

1. Read the raw values via `prev[key]`; skip the property if it's absent (`nil`) instead of crashing on `nil.each` (also addresses the same-line crash in #580).
2. Read the rewritten value via method access (`prev.public_send(follow)`), which honors `(as …)`.
3. When the rewritten value differs from the first raw value — i.e. a rewrite is in effect — use the rewritten value; otherwise copy every raw value, preserving the multi-valued behavior from #520.

## Tests

- `test_follow_honors_as_rewrite` — `(as who assignee)` now copies `4536`, not `777`.
- `test_follow_skips_missing_property` — following an absent property no longer crashes.
- Existing `test_follow_multivalued` still passes (all values copied for genuine multi-valued follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qq9uDEo7ckQ959pCdiDpei

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq9uDEo7ckQ959pCdiDpei)_