### PR TITLE
fix: #597 reserve a per-run slot to stop before a step overruns the timeout

### DIFF
--- a/lib/fbe/conclude.rb
+++ b/lib/fbe/conclude.rb
@@ -19,17 +19,20 @@ require_relative 'over'
 # @param [Loog] loog The logging facility
 # @param [Time] epoch When the entire update started
 # @param [Time] kickoff When the particular judge started
+# @param [Integer] slot Seconds a single iteration may need; the loop stops
+#   before starting a new one when less than this many seconds remain in the
+#   timeout (or lifetime) budget
 # @yield [Factbase::Fact] The fact
 def Fbe.conclude(
   fb: Fbe.fb, judge: $judge, loog: $loog, options: $options, global: $global,
-  epoch: $epoch || Time.now, kickoff: $kickoff || Time.now, &
+  epoch: $epoch || Time.now, kickoff: $kickoff || Time.now, slot: 1, &
 )
   raise(Fbe::Error, 'The fb is nil') if fb.nil?
   raise(Fbe::Error, 'The $judge is not set') if judge.nil?
   raise(Fbe::Error, 'The $global is not set') if global.nil?
   raise(Fbe::Error, 'The $options is not set') if options.nil?
   raise(Fbe::Error, 'The $loog is not set') if loog.nil?
-  c = Fbe::Conclude.new(fb:, judge:, loog:, options:, global:, epoch:, kickoff:)
+  c = Fbe::Conclude.new(fb:, judge:, loog:, options:, global:, epoch:, kickoff:, slot:)
   c.instance_eval(&)
 end
 
@@ -66,7 +69,8 @@ class Fbe::Conclude
   # @param [Loog] loog The logging facility
   # @param [Time] epoch When the entire update started
   # @param [Time] kickoff When the particular judge started
-  def initialize(fb:, judge:, global:, options:, loog:, epoch:, kickoff:)
+  # @param [Integer] slot Seconds a single iteration may need
+  def initialize(fb:, judge:, global:, options:, loog:, epoch:, kickoff:, slot: 1)
     @fb = fb
     @judge = judge
     @loog = loog
@@ -74,6 +78,7 @@ class Fbe::Conclude
     @global = global
     @epoch = epoch
     @kickoff = kickoff
+    @slot = slot
     @query = nil
     @follows = []
     @lifetime = true
@@ -184,6 +189,13 @@ class Fbe::Conclude
   # monitoring quotas and timeouts, and processing each fact through
   # the provided block.
   #
+  # Besides the {Fbe.over?} check (which stops once the elapsed time crosses
+  # the fixed 90% margin of the timeout), the loop also reserves one +@slot+
+  # up front: it stops before starting a new iteration when fewer than +@slot+
+  # seconds remain in the timeout (or lifetime) budget. This prevents a slow
+  # single step from starting late and overrunning the hard timeout enforced
+  # by the +judges+ gem.
+  #
   # @yield [Factbase::Transaction, Factbase::Fact] Transaction and the matching fact
   # @return [Integer] The count of facts processed
   # @example
@@ -207,6 +219,14 @@ class Fbe::Conclude
         global: @global, options: @options, loog: @loog, epoch: @epoch, kickoff: @kickoff,
         quota_aware: @quota, lifetime_aware: @lifetime, timeout_aware: @timeout
       )
+      if @timeout && @options.timeout && @options.timeout - (Time.now - @kickoff) < @slot
+        @loog.info("Less than #{@slot}s left before the timeout, must stop here")
+        break
+      end
+      if @lifetime && @options.lifetime && @options.lifetime - (Time.now - @epoch) < @slot
+        @loog.info("Less than #{@slot}s left before the lifetime ends, must stop here")
+        break
+      end
       @fb.txn do |fbt|
         n = yield(fbt, a)
         unless n.nil?

--- a/test/fbe/test_conclude.rb
+++ b/test/fbe/test_conclude.rb
@@ -163,6 +163,53 @@ class TestConclude < Fbe::Test
     assert_equal(1, fb.size)
   end
 
+  def test_slot_stops_before_timeout_overrun
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.insert.foo = 2
+    options = Judges::Options.new('timeout=10')
+    Fbe.conclude(fb:, judge: 'x', options:, global: {}, loog: Loog::NULL, kickoff: Time.now - 5, slot: 6) do
+      quota_unaware
+      on('(exists foo)')
+      draw do |n, prev|
+        n.sum = prev.foo
+        'A long enough description to satisfy the requirements of the draw.'
+      end
+    end
+    assert_equal(0, fb.query('(exists sum)').each.to_a.size)
+  end
+
+  def test_slot_stops_before_lifetime_overrun
+    fb = Factbase.new
+    fb.insert.foo = 1
+    fb.insert.foo = 2
+    options = Judges::Options.new('lifetime=10')
+    Fbe.conclude(fb:, judge: 'x', options:, global: {}, loog: Loog::NULL, epoch: Time.now - 5, slot: 6) do
+      quota_unaware
+      on('(exists foo)')
+      draw do |n, prev|
+        n.sum = prev.foo
+        'A long enough description to satisfy the requirements of the draw.'
+      end
+    end
+    assert_equal(0, fb.query('(exists sum)').each.to_a.size)
+  end
+
+  def test_default_slot_does_not_stop_early
+    fb = Factbase.new
+    fb.insert.foo = 1
+    options = Judges::Options.new('timeout=10')
+    Fbe.conclude(fb:, judge: 'x', options:, global: {}, loog: Loog::NULL, kickoff: Time.now) do
+      quota_unaware
+      on('(exists foo)')
+      draw do |n, prev|
+        n.sum = prev.foo
+        'A long enough description to satisfy the requirements of the draw.'
+      end
+    end
+    assert_equal(1, fb.query('(exists sum)').each.to_a.size)
+  end
+
   def test_draw_block_returning_non_string_does_not_crash
     $fb = Factbase.new
     $global = {}


### PR DESCRIPTION
Closes #597.

## Problem

`Fbe.consider`/`Fbe.draw` (via the shared `roll` loop in `lib/fbe/conclude.rb`) only stop iterating when `Fbe.over?` reports the budget spent — a fixed 10% margin before the per-judge timeout (`timeout * 0.9`). For judges whose every iteration makes several network calls (e.g. `zerocracy/j`'s `pay-reward`), a step that starts near the end of the budget overruns, and the `judges` gem's hard `Timeout.timeout(options.timeout)` kills the judge. The loop-level check can't help once a slow step is already in flight.

## Change

- Add an integer `slot:` parameter (seconds needed per run, default `1`) to `Fbe.conclude` and the `Fbe::Conclude` constructor, plumbed into `roll`.
- In the loop, right after the existing `break if Fbe.over?(...)`, also break when less than one slot remains in the timeout budget (`options.timeout - (Time.now - kickoff) < slot`) and likewise against the lifetime/epoch budget. The `timeout_unaware`/`lifetime_unaware` flags are respected.
- Default `slot: 1` is backward-safe, since `over?` already stops earlier at `timeout * 0.9`; only judges that raise `slot` change behavior.

## Tests

Added `test_slot_stops_before_timeout_overrun`, `test_slot_stops_before_lifetime_overrun`, and `test_default_slot_does_not_stop_early`. Full `test_conclude.rb` suite and RuboCop pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YnD78F7h6QWHvXYnXWS8U

---
_Generated by [Claude Code](https://claude.ai/code/session_015YnD78F7h6QWHvXYnXWS8U)_