### PR TITLE
#600 Derive Impatient timeout from options.timeout

### DIFF
--- a/lib/fbe/fb.rb
+++ b/lib/fbe/fb.rb
@@ -60,7 +60,7 @@ def Fbe.fb(fb: $fb, global: $global, options: $options, loog: $loog)
             ),
             loog
           ),
-          timeout: 60
+          timeout: options.timeout || 60
         )
       end
   end


### PR DESCRIPTION
Fixes #600

Replaced the hardcoded `timeout: 60` in `Factbase::Impatient.new` with `timeout: options.timeout || 60`, so the query-level cap matches the judge budget that `roll` uses for graceful timeout-stop.