### PR TITLE
#586 Fix malformed OR query in Fbe.kill_if — missing space in .join

### DIFF
--- a/lib/fbe/kill_if.rb
+++ b/lib/fbe/kill_if.rb
@@ -20,5 +20,5 @@ def Fbe.kill_if(facts, fb: Fbe.fb, fid: '_id')
     ids << f[fid].first
   end
   return 0 if ids.empty?
-  fb.query("(or #{ids.map { |id| "(eq #{fid} #{id})" }.join})").delete!
+  fb.query("(or #{ids.map { |id| "(eq #{fid} #{id})" }.join(' ')})").delete!
 end

--- a/test/fbe/test_kill_if.rb
+++ b/test/fbe/test_kill_if.rb
@@ -37,6 +37,16 @@ class TestKillIf < Fbe::Test
     assert_equal(1, fb.size)
   end
 
+  def test_deletes_multiple_facts
+    fb = Factbase.new
+    fb.insert.then { |f| f._id = 10 }
+    fb.insert.then { |f| f._id = 20 }
+    fb.insert.then { |f| f._id = 30 }
+    facts = fb.query('(always)').each.to_a
+    assert_equal(2, Fbe.kill_if([facts[0], facts[2]], fb:))
+    assert_equal(1, fb.size)
+  end
+
   def test_returns_zero_when_facts_empty
     fb = Factbase.new
     assert_equal(0, Fbe.kill_if([], fb:))


### PR DESCRIPTION
Fixes #586

`kill_if.rb:23` used `.join` with no argument, producing `(or (eq _id 1)(eq _id 2))` instead of the correct `(or (eq _id 1) (eq _id 2))` — missing space between sub-expressions. The Factbase parser would either fail or silently return wrong results for multi-fact calls.

Changed to `.join(' ')` and added `test_deletes_multiple_facts` that calls `kill_if` with two facts and verifies only they are deleted.