### PR TITLE
#581 Revert counter decrement when RateLimit request fails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,6 +100,7 @@ Elegant/GoodMethodName:
     - total_issues_created
     - total_releases_published
     - track_request
+    - untrack_request
     - unmask_repos
     - update_organization_membership
     - user_name_by_id

--- a/lib/fbe/middleware/rate_limit.rb
+++ b/lib/fbe/middleware/rate_limit.rb
@@ -50,6 +50,9 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
         @lock.synchronize { sync(response_env, env.url.path) }
       end
     end
+  rescue StandardError
+    @lock.synchronize { untrack_request(env.url.path) } unless env.url.path == '/rate_limit'
+    raise
   end
 
   # Returns the remaining requests count tracked by this middleware.
@@ -88,6 +91,17 @@ class Fbe::Middleware::RateLimit < Faraday::Middleware
       @searchleft -= 1 if @searchleft&.positive?
     elsif @remaining&.positive?
       @remaining -= 1
+    end
+  end
+
+  # Reverts the counter decrement when the request fails.
+  def untrack_request(path = nil)
+    return unless @counter&.positive?
+    @counter -= 1
+    if path&.start_with?('/search/')
+      @searchleft += 1 if @searchleft&.positive?
+    elsif @remaining&.positive?
+      @remaining += 1
     end
   end
 


### PR DESCRIPTION
Fixes #581

`track_request` decrements `@remaining`/`@searchleft` before the HTTP call. If `@app.call` raises (network error, timeout), `sync` never fires and the counters stay decremented — drift grows over time.

Added `untrack_request` that reverses the decrement, called from a `rescue StandardError` in `call`.