### PR TITLE
#551 Move delete! inside txn to prevent data loss on insert failure

### DIFF
--- a/lib/fbe/delete.rb
+++ b/lib/fbe/delete.rb
@@ -33,8 +33,8 @@ def Fbe.delete(fact, *props, fb: Fbe.fb, id: '_id')
     next if props.include?(k)
     before[k] = fact[k]
   end
-  fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
+    fbt.query("(eq #{id} #{i})").delete!
     c = fbt.insert
     f = c
     while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)

--- a/lib/fbe/delete_one.rb
+++ b/lib/fbe/delete_one.rb
@@ -32,8 +32,8 @@ def Fbe.delete_one(fact, prop, value, fb: Fbe.fb, id: '_id')
   return if nv == before[prop]
   before[prop] = nv
   before.delete(prop) if nv.empty?
-  fb.query("(eq #{id} #{i})").delete!
   fb.txn do |fbt|
+    fbt.query("(eq #{id} #{i})").delete!
     c = fbt.insert
     f = c
     while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)

--- a/lib/fbe/overwrite.rb
+++ b/lib/fbe/overwrite.rb
@@ -65,8 +65,8 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
     end
     id = fact[fid]&.first
     raise(Fbe::Error, "There is no #{fid} in the fact, cannot use Fbe.overwrite") if id.nil?
-    raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
     fb.txn do |fbt|
+      raise(Fbe::Error, "No facts by #{fid} = #{id}") if fbt.query("(eq #{fid} #{id})").delete!.zero?
       n = fbt.insert
       f = n
       while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)
@@ -101,8 +101,8 @@ def Fbe.overwrite(fact, property_or_hash, values = nil, fb: Fbe.fb, fid: '_id') 
   end
   id = fact[fid]&.first
   raise(Fbe::Error, "There is no #{fid} in the fact, cannot use Fbe.overwrite") if id.nil?
-  raise(Fbe::Error, "No facts by #{fid} = #{id}") if fb.query("(eq #{fid} #{id})").delete!.zero?
   fb.txn do |fbt|
+    raise(Fbe::Error, "No facts by #{fid} = #{id}") if fbt.query("(eq #{fid} #{id})").delete!.zero?
     n = fbt.insert
     f = n
     while f.instance_variable_defined?(:@fact) || f.instance_variable_defined?(:@origin)


### PR DESCRIPTION
Fixes #551

In `overwrite.rb` (both hash and scalar paths), `delete.rb`, and `delete_one.rb` the `delete!` call ran outside `fb.txn`, so if the subsequent `fbt.insert` raised, the delete was already committed — the fact was lost with no replacement.

Moved `delete!` inside the `fb.txn` block and changed `fb.query(...).delete!` to `fbt.query(...).delete!` so the transaction rollback covers both steps atomically.