### PR TITLE
#584 Pin volodya-lombrozo/pdd-action to SHA

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54


### PR DESCRIPTION
## Problem
The `volodya-lombrozo/pdd-action` is pinned to `@master`, which is a mutable tag. This poses a supply-chain security risk: the action could be silently replaced with a malicious version.

## Solution
Pinned to commit SHA `69842b56627431c5f232f5ea2dc2fca82f409c54`.

Closes #584