### PR TITLE
#585 Pin g4s8/xcop-action to SHA

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@4e93f123cab886ca8e481a737ee586bc9f02d228


### PR DESCRIPTION
## Problem
The `g4s8/xcop-action` is pinned to `@master`, a mutable tag — supply-chain security risk.

## Solution
Pinned to commit SHA `4e93f123cab886ca8e481a737ee586bc9f02d228`.

Closes #585