### PR TITLE
#587 Add permissions blocks to all workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,8 @@ name: actionlint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   actionlint:
     timeout-minutes: 15

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,8 @@ name: codecov
   push:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   codecov:
     timeout-minutes: 15

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -10,6 +10,8 @@ name: copyrights
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   copyrights:
     timeout-minutes: 15

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -11,6 +11,8 @@ name: markdown-lint
     branches:
       - master
     paths-ignore: ['paper/**', 'sandbox/**']
+permissions:
+  contents: read
 concurrency:
   group: markdown-lint-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -10,6 +10,8 @@ name: pdd
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   pdd:
     timeout-minutes: 15

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -10,6 +10,8 @@ name: rake
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   rake:
     strategy:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,8 @@ name: reuse
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   reuse:
     timeout-minutes: 15

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -10,6 +10,8 @@ name: typos
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   typos:
     timeout-minutes: 15

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -6,6 +6,8 @@ name: xcop
 'on':
   push:
   pull_request:
+permissions:
+  contents: read
 jobs:
   xcop:
     timeout-minutes: 15

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -10,6 +10,8 @@ name: yamllint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   yamllint:
     timeout-minutes: 15


### PR DESCRIPTION
## Problem
All 10 workflow files lack explicit `permissions:` blocks. By default, GitHub Actions tokens have read/write permissions across all scopes, which is unnecessarily broad for CI checks and poses a security risk.

## Solution
Added `permissions: contents: read` to all 10 workflow files. This grants only read access to repository contents — the minimum needed for `actions/checkout` and all lint/check steps in these workflows.

Affected files:
- actionlint.yml
- codecov.yml
- copyrights.yml
- markdown-lint.yml
- pdd.yml
- rake.yml
- reuse.yml
- typos.yml
- xcop.yml
- yamllint.yml

Closes #587