### PR TITLE
#589 Enable Renovate SHA pinning for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Problem
Renovate is configured with only `config:base`, which does not automatically pin GitHub Actions to commit SHAs. Without this, action tags may become stale, and once we pin manually (see #588), Renovate should keep them up to date.

## Solution
Added `helpers:pinGitHubActionDigests` to the `extends` array. This tells Renovate to:
- Automatically convert tag references to commit SHAs in PRs
- Keep SHA pins updated when upstream actions release new versions

Closes #589