### PR TITLE
#579 Validate variable substitution in Award text

### DIFF
--- a/lib/fbe/award.rb
+++ b/lib/fbe/award.rb
@@ -356,7 +356,12 @@ class Fbe::Award
     #   bill.line(50, "for code review")
     def line(value, text)
       return if value.zero?
-      text = text.gsub(/\$\{([a-z_0-9]+)\}/) { |_x| @vars[Regexp.last_match[1].to_sym] }
+      text =
+        text.gsub(/\$\{([a-z_0-9]+)\}/) do |_x|
+          k = Regexp.last_match[1].to_sym
+          raise(Fbe::Error, "Undefined variable '#{k}' used in award text: #{text}") unless @vars.key?(k)
+          @vars[k]
+        end
       @lines << { v: value, t: text }
     end
 
@@ -443,7 +448,12 @@ class Fbe::Award
     #   bylaw.let(:points, 50)
     #   bylaw.line("award ${points} points")
     def line(line)
-      line = line.gsub(/\$\{([a-z_0-9]+)\}/) { |_x| "**#{@lets[Regexp.last_match[1].to_sym]}**" }
+      line =
+        line.gsub(/\$\{([a-z_0-9]+)\}/) do |_x|
+          k = Regexp.last_match[1].to_sym
+          raise(Fbe::Error, "Undefined variable '#{k}' used in bylaw text: #{line}") unless @lets.key?(k)
+          "**#{@lets[k]}**"
+        end
       @lines << line
     end
 

--- a/test/fbe/test_award.rb
+++ b/test/fbe/test_award.rb
@@ -129,4 +129,16 @@ class TestAward < Fbe::Test
     g = Fbe::Award.new('(award (give 0 "for none"))').bill.greeting
     assert_equal('You\'ve earned nothing. ', g, g)
   end
+
+  def test_bill_raises_on_undefined_var
+    a = Fbe::Award.new('(award (give 10 "test ${missing}"))')
+    assert_raises(Fbe::Error) { a.bill }
+  end
+
+  def test_bylaw_raises_on_undefined_var
+    a = Fbe::Award.new(
+      '(award (aka (give 10 "points") "${undefined} points"))'
+    )
+    assert_raises(Fbe::Error) { a.bylaw }
+  end
 end

--- a/test/fbe/test_award.rb
+++ b/test/fbe/test_award.rb
@@ -136,9 +136,7 @@ class TestAward < Fbe::Test
   end
 
   def test_bylaw_raises_on_undefined_var
-    a = Fbe::Award.new(
-      '(award (aka (give 10 "points") "${undefined} points"))'
-    )
+    a = Fbe::Award.new('(award (aka (give 10 "points") "${undefined} points"))')
     assert_raises(Fbe::Error) { a.bylaw }
   end
 end


### PR DESCRIPTION
## Problem
When `${var}` is used in award or bylaw text, an undefined variable silently produces `nil` or `"**nil**"` in the output, hiding configuration errors.

## Solution
Both `Bill#line` and `Bylaw#line` now check that the variable exists via `key?` before substitution. If undefined, a descriptive `Fbe::Error` is raised with the variable name and the failing text.

Closes #579