### PR TITLE
#578 Guard division by zero in Award calc

### DIFF
--- a/lib/fbe/award.rb
+++ b/lib/fbe/award.rb
@@ -192,7 +192,9 @@ class Fbe::Award
       when :gte
         to_val(@operands[0], bill) >= to_val(@operands[1], bill)
       when :div
-        to_val(@operands[0], bill) / to_val(@operands[1], bill)
+        divisor = to_val(@operands[1], bill)
+        raise(Fbe::Error, 'Division by zero in award calculation') if divisor.zero?
+        to_val(@operands[0], bill) / divisor
       when :times
         to_val(@operands[0], bill) * to_val(@operands[1], bill)
       when :plus

--- a/test/fbe/test_award.rb
+++ b/test/fbe/test_award.rb
@@ -129,4 +129,9 @@ class TestAward < Fbe::Test
     g = Fbe::Award.new('(award (give 0 "for none"))').bill.greeting
     assert_equal('You\'ve earned nothing. ', g, g)
   end
+
+  def test_division_by_zero_raises_error
+    a = Fbe::Award.new('(award (set x (div 10 0)) (give x "test"))')
+    assert_raises(Fbe::Error) { a.bill }
+  end
 end


### PR DESCRIPTION
## Problem
When `(div n 0)` is evaluated in an award expression, Ruby raises `ZeroDivisionError` which is not caught and results in a 500-style crash with an unhelpful message.

## Solution
Added a guard in the `:div` branch of `BTerm#calc`: if the divisor is zero, a descriptive `Fbe::Error` is raised instead of letting the raw `ZeroDivisionError` propagate.

Closes #578