### PR TITLE
#616: deduplicate repos matched by overlapping masks in unmask_repos

### DIFF
--- a/lib/fbe/unmask_repos.rb
+++ b/lib/fbe/unmask_repos.rb
@@ -92,6 +92,7 @@ def Fbe.unmask_repos( # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticCompl
     re = Fbe.mask_to_regex(mask[1..])
     repos.reject! { |r| re.match?(r) }
   end
+  repos.uniq!
   repos.reject! { |repo| octo.repository(repo)[:archived] }
   raise(Fbe::Error, "No repos found matching: #{options.repositories.inspect}") if repos.empty?
   repos.shuffle!

--- a/test/fbe/test_unmask_repos.rb
+++ b/test/fbe/test_unmask_repos.rb
@@ -50,6 +50,13 @@ class TestUnmaskRepos < Fbe::Test
     assert_equal(2, list.size)
   end
 
+  def test_deduplicates_repos_matched_by_overlapping_masks
+    opts = Judges::Options.new({ 'testing' => true, 'repositories' => 'yegor256/factbase,Yegor256/*' })
+    list = Fbe.unmask_repos(options: opts, global: {}, loog: Loog::NULL)
+    assert_equal(list.uniq.size, list.size, "duplicates found in #{list.inspect}")
+    assert_includes(list, 'yegor256/factbase')
+  end
+
   def test_mask_to_regex_treats_dot_as_literal
     re = Fbe.mask_to_regex('zold-io/blog.zold.io')
     assert_match(re, 'zold-io/blog.zold.io')


### PR DESCRIPTION
Closes #616.

`Fbe.unmask_repos` appended matches from every inclusion mask independently, so a repository matched by both an exact-name mask and a wildcard mask (e.g. `yegor256/factbase,Yegor256/*`) survived to the final list twice and was yielded — and processed — twice per run. A `repos.uniq!` now runs right after the exclusion pass, before the archived-repos filter, so duplicates also don't cost an extra `octo.repository` call each.

The new test reproduces the overlap from the issue and asserts the list is duplicate-free while still containing the doubly-matched repo; it fails on master.

Tests: 13 tests, 0 failures; rubocop: no offenses.
