### PR TITLE
Fix #621: wrap Iterate#over block errors as Fbe::Error instead of raise(e.class)

### DIFF
--- a/lib/fbe/iterate.rb
+++ b/lib/fbe/iterate.rb
@@ -330,7 +330,7 @@ class Fbe::Iterate
             rescue Fbe::OffQuota
               raise
             rescue StandardError => e
-              raise(e.class, "Failure in repository ##{repo} at ##{nxt}: #{e.message}")
+              raise(Fbe::Error, "Failure in repository ##{repo} at ##{nxt}: #{e.message}")
             end
           end
         unless before[repo].is_a?(Integer)

--- a/test/fbe/test_iterate.rb
+++ b/test/fbe/test_iterate.rb
@@ -530,7 +530,7 @@ class TestIterate < Fbe::Test
     fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
     fb.insert.foo = 42
     ex =
-      assert_raises(StandardError) do
+      assert_raises(Fbe::Error) do
         Fbe.iterate(fb:, loog: Loog::NULL, options: opts, global: {}, epoch: Time.now, kickoff: Time.now) do
           as('context_test')
           by('(agg (always) (max foo))')
@@ -543,6 +543,40 @@ class TestIterate < Fbe::Test
     assert_includes(ex.message, '42', "Expected message to contain item id, got: #{ex.message.inspect}")
     assert_match(/repo/i, ex.message, "Expected message to mention repo, got: #{ex.message.inspect}")
     assert_includes(ex.message, 'boom', "Expected original message preserved, got: #{ex.message.inspect}")
+  end
+
+  def test_wraps_octokit_error_as_fbe_error_with_context
+    opts = Judges::Options.new(['repositories=foo/bar', 'testing=true'])
+    fb = Fbe.fb(fb: Factbase.new, global: {}, options: opts, loog: Loog::NULL)
+    fb.insert.foo = 42
+    err =
+      Octokit::ServiceUnavailable.new(
+        {
+          status: 503,
+          method: :get,
+          url: 'https://api.github.com/',
+          body: 'Service Unavailable',
+          response_headers: {}
+        }
+      )
+    ex =
+      assert_raises(Fbe::Error) do
+        Fbe.iterate(fb:, loog: Loog::NULL, options: opts, global: {}, epoch: Time.now, kickoff: Time.now) do
+          as('octokit_context_test')
+          by('(agg (always) (max foo))')
+          repeats(1)
+          over do |_repository, _foo|
+            raise(err)
+          end
+        end
+      end
+    assert_includes(ex.message, '42', "Expected message to contain item id, got: #{ex.message.inspect}")
+    assert_match(/repo/i, ex.message, "Expected message to mention repo, got: #{ex.message.inspect}")
+    assert_includes(
+      ex.message,
+      err.message,
+      "Expected original Octokit message preserved, got: #{ex.message.inspect}"
+    )
   end
 
   def test_does_not_swallow_off_quota_when_block_raises


### PR DESCRIPTION
Fixes #621.

In `Fbe::Iterate#over` (`lib/fbe/iterate.rb:333`), the rescue around `yield(repo, nxt)` re-raises with:

```ruby
raise(e.class, "Failure in repository ##{repo} at ##{nxt}: #{e.message}")
```

That is equivalent to `e.class.new(msg)`. This works for plain exceptions, but `Octokit::Error#initialize(response)` expects a Faraday response `Hash`, not a `String`.

When the block raises an Octokit error (for example, `Octokit::ServiceUnavailable` from a GitHub 503), reconstruction sets `@response` to the message string. `Octokit::Error#build_error_message` then evaluates:

```ruby
@response[:method]
```

Since `@response` is actually a `String`, Ruby attempts `String#[](:method)`, which raises:

```
TypeError: no implicit conversion of Symbol into Integer
```

As a result, the original 503 is lost and replaced by a confusing `TypeError`.

This is a regression introduced by the context-adding change in #446 / #455. Adding repository/item context was the right idea, but reconstructing arbitrary exception classes from a string is unsafe for `Octokit::Error`.

## Change

Wrap all non-`Fbe::OffQuota` exceptions as `Fbe::Error`, matching the existing pattern used in `award.rb` and `octo.rb`:

```ruby
rescue Fbe::OffQuota
  raise
rescue StandardError => e
  raise(
    Fbe::Error,
    "Failure in repository ##{repo} at ##{nxt}: #{e.message}"
  )
end
```

`Fbe::OffQuota` is still re-raised unchanged, so the existing handler at the bottom of `over` continues to work as before.

The repository/item context is preserved in the message, and Ruby automatically sets the wrapped exception as the `cause`.

## Tests

- `test_preserves_repo_and_item_context_when_block_raises`
  - Now asserts `Fbe::Error`.
  - Still verifies the repository, item ID, and original error message are present.

- `test_wraps_octokit_error_as_fbe_error_with_context`
  - Raises `Octokit::ServiceUnavailable` from the block.
  - Verifies a contextual `Fbe::Error` is raised instead of a `TypeError`.

## CI

```sh
bundle exec rake green
```

Passed locally (tests, RuboCop, Picks, and YARD).